### PR TITLE
fix: cast base output to translator dtype in Vec2VecForEmbedding

### DIFF
--- a/src/protify/base_models/get_base_models.py
+++ b/src/protify/base_models/get_base_models.py
@@ -40,7 +40,10 @@ class BaseModelArguments:
 
 
 def get_base_model(model_name: str, masked_lm: bool = False, dtype=None, model_path: str = None):
-    if 'random' in model_name.lower():
+    if 'vec2vec' in model_name.lower():
+        from .vec2vec import build_vec2vec_model
+        return build_vec2vec_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
+    elif 'random' in model_name.lower():
         from .random import build_random_model
         return build_random_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
     elif 'esm2' in model_name.lower() and model_name.lower().count('esm2') == 1:
@@ -82,9 +85,6 @@ def get_base_model(model_name: str, masked_lm: bool = False, dtype=None, model_p
     elif 'e1' in model_name.lower():
         from .e1 import build_e1_model
         return build_e1_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
-    elif 'vec2vec' in model_name.lower():
-        from .vec2vec import build_vec2vec_model
-        return build_vec2vec_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
     elif 'calm' in model_name.lower():
         from .calm import build_calm_model
         return build_calm_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
@@ -142,6 +142,9 @@ def get_tokenizer(model_name: str, model_path: str = None):
         from .custom_model import build_custom_tokenizer
         assert model_path is not None, "model_path is required for custom models. Use --model_paths and --model_types custom."
         return build_custom_tokenizer(model_path)
+    if 'vec2vec' in model_name.lower():
+        from .vec2vec import get_vec2vec_tokenizer
+        return get_vec2vec_tokenizer(model_name, model_path=model_path)
     if 'esm2' in model_name.lower() or 'random' in model_name.lower() or 'dsm' in model_name.lower():
         from .esm2 import get_esm2_tokenizer
         return get_esm2_tokenizer(model_name, model_path=model_path)

--- a/src/protify/base_models/supported_models.py
+++ b/src/protify/base_models/supported_models.py
@@ -69,6 +69,10 @@ all_presets_with_paths = {
     'vec2vec-ESM2-150-ESM2-650': 'lhallee/ESM2-150-ESM2-650-sequence-sequence',
     'vec2vec-ESM2-150-ESM2-3B': 'lhallee/ESM2-150-ESM2-3B-sequence-sequence',
     'vec2vec-ESM2-650-ESM2-3B': 'lhallee/ESM2-650-ESM2-3B-sequence-sequence',
+    # Contrastive vec2vec adapters (ESM2-650 -> NLP), from run with
+    # --paired_batches --loss_coefficient_contrastive 4.0 --hub_suffix contrastive
+    'vec2vec-ESM2-650-ModernBERT-base-contrastive': 'lhallee/ESM2-650-ModernBERT-base-sequence-sequence-contrastive',
+    'vec2vec-ESM2-650-ModernBERT-large-contrastive': 'lhallee/ESM2-650-ModernBERT-large-sequence-sequence-contrastive',
     # CaLM models (from calm.py)
     'CaLM': 'multimolecule/calm',
 }

--- a/src/protify/base_models/vec2vec.py
+++ b/src/protify/base_models/vec2vec.py
@@ -536,6 +536,8 @@ presets = {
     'vec2vec-ESM2-150-ESM2-650': 'lhallee/ESM2-150-ESM2-650-sequence-sequence',
     'vec2vec-ESM2-150-ESM2-3B': 'lhallee/ESM2-150-ESM2-3B-sequence-sequence',
     'vec2vec-ESM2-650-ESM2-3B': 'lhallee/ESM2-650-ESM2-3B-sequence-sequence',
+    'vec2vec-ESM2-650-ModernBERT-base-contrastive': 'lhallee/ESM2-650-ModernBERT-base-sequence-sequence-contrastive',
+    'vec2vec-ESM2-650-ModernBERT-large-contrastive': 'lhallee/ESM2-650-ModernBERT-large-sequence-sequence-contrastive',
 }
 
 
@@ -629,8 +631,13 @@ def get_vec2vec_tokenizer(preset: str, model_path: str = None):
     try:
         tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
     except Exception:
-        model = AutoModel.from_pretrained(path, trust_remote_code=True)
-        tokenizer = AutoTokenizer.from_pretrained(model.config.tokenizer_name)
+        # vec2vec repos often don't ship a tokenizer; AutoModel can't load a
+        # `vec2vec` model_type via AutoFactory either. Resolve the source
+        # encoder from the Vec2VecConfig and load its tokenizer directly.
+        config = Vec2VecConfig.from_pretrained(path)
+        encoder_a_preset = config.encoder_names[0]
+        encoder_a_path = all_presets_with_paths[encoder_a_preset]
+        tokenizer = AutoTokenizer.from_pretrained(encoder_a_path, trust_remote_code=True)
     return Vec2VecTokenizerWrapper(tokenizer)
 
 

--- a/src/protify/base_models/vec2vec.py
+++ b/src/protify/base_models/vec2vec.py
@@ -599,10 +599,15 @@ class Vec2VecForEmbedding(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         base_state = self.base_model(input_ids, attention_mask=attention_mask).last_hidden_state
+        # Translator weights are loaded fp32; under autocast, base_state may be
+        # bf16 which collides with the Linear weight dtype. Cast base output to
+        # the translator's parameter dtype so autocast does not hand a bf16
+        # input to an fp32 Linear mid-way through the wrapper.
+        translator_dtype = next(self.vec2vec_model.parameters()).dtype
         if self.learned_pooling:
             # Translator has its own AttentionPooler; pass raw hidden states.
             translated = self.vec2vec_model.translate(
-                base_state,
+                base_state.to(translator_dtype),
                 src=self.model_name_a,
                 tgt=self.model_name_b,
                 attention_mask=attention_mask,
@@ -612,7 +617,7 @@ class Vec2VecForEmbedding(nn.Module):
             if self.normalize:
                 base_vec = F.normalize(base_vec, p=2, dim=1)
             translated = self.vec2vec_model.translate(
-                base_vec,
+                base_vec.to(translator_dtype),
                 src=self.model_name_a,
                 tgt=self.model_name_b,
             )

--- a/src/protify/visualization/plot_result.py
+++ b/src/protify/visualization/plot_result.py
@@ -108,7 +108,8 @@ def plot_radar(*,
                data: List[List[float]],
                title: str,
                outfile: Path,
-               normalize: bool = False):
+               normalize: bool = False,
+               no_title: bool = False):
     # Use pretty names for categories (datasets) and models
     pretty_categories = [DATASET_NAMES.get(cat, cat) for cat in categories]
     pretty_models = [MODEL_NAMES.get(m, m) for m in models]
@@ -137,7 +138,8 @@ def plot_radar(*,
         ax.fill(ang, val, alpha=.25, color=palette[i])
 
     ax.grid(True)
-    plt.title(title, pad=20)
+    if not no_title:
+        plt.title(title, pad=20)
     plt.legend(bbox_to_anchor=(1.25, 1.05))
     plt.tight_layout()
     plt.savefig(outfile, dpi=450, bbox_inches="tight")
@@ -148,7 +150,8 @@ def bar_plot(datasets: List[str],
              models: List[str],
              data: List[List[float]],
              metric_name: str,
-             outfile: Path):
+             outfile: Path,
+             no_title: bool = False):
     rows = [
         {"Dataset": DATASET_NAMES.get(d, d), "Model": MODEL_NAMES.get(m, m), "Score": s}
         for m, col in zip(models, data)
@@ -157,7 +160,8 @@ def bar_plot(datasets: List[str],
     dfp = pd.DataFrame(rows)
     plt.figure(figsize=(max(12, .8 * len(datasets)), 8))
     sns.barplot(dfp, x="Dataset", y="Score", hue="Model")
-    plt.title(f"{metric_name} across datasets (Cls→F1, Reg→Spearman)")
+    if not no_title:
+        plt.title(f"{metric_name} across datasets (Cls→F1, Reg→Spearman)")
     plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
     plt.savefig(outfile, dpi=450, bbox_inches="tight")
@@ -190,7 +194,8 @@ def heatmap_plot(datasets: List[str],
                  outfile: Path,
                  normalize: bool = False,
                  display_strings: List[List[str]] = None,
-                 no_std: bool = False):
+                 no_std: bool = False,
+                 no_title: bool = False):
     """
     Create a heatmap plot.
     
@@ -323,7 +328,8 @@ def heatmap_plot(datasets: List[str],
     else:
         title = f'{annot_label} Heatmap (Cls\u2192F1, Reg\u2192Spearman)\nRaw metric values'
         
-    plt.title(title, pad=20, fontsize=21)
+    if not no_title:
+        plt.title(title, pad=20, fontsize=21)
     plt.ylabel('Dataset', fontsize=17)
     plt.xlabel('Model', fontsize=17)
     plt.tight_layout()
@@ -339,7 +345,7 @@ def load_tsv(tsv: Path) -> pd.DataFrame:
     return df
 
 
-def create_plots(tsv: str, outdir: str, no_std: bool = False):
+def create_plots(tsv: str, outdir: str, no_std: bool = False, no_title: bool = False):
     tsv, outdir = Path(tsv), Path(outdir)
     df = load_tsv(tsv)
     models = [c for c in df.columns if c != "dataset"]
@@ -461,27 +467,29 @@ def create_plots(tsv: str, outdir: str, no_std: bool = False):
                data=plot_matrix,
                title=subtitle,
                outfile=radar_path,
-               normalize=False)
+               normalize=False,
+               no_title=no_title)
     plot_radar(categories=datasets,
                models=models,
                data=plot_matrix,
                title=subtitle + " (Normalized)",
                outfile=radar_path_norm,
-               normalize=True)
+               normalize=True,
+               no_title=no_title)
     # Bar and heatmap use sorted order
-    bar_plot(datasets, sorted_models, sorted_plot_matrix, metric_name, bar_path)
+    bar_plot(datasets, sorted_models, sorted_plot_matrix, metric_name, bar_path, no_title=no_title)
     # Normalized bar plot
     # For bar plot normalization, use min-max per dataset (column-wise normalization)
     arr = np.asarray(sorted_plot_matrix)
     rng = np.where(np.ptp(arr, axis=0) == 0, 1, np.ptp(arr, axis=0))
     arr_norm = (arr - arr.min(0)) / rng
-    bar_plot(datasets, sorted_models, arr_norm.tolist(), metric_name + " (Normalized)", bar_path_norm)
+    bar_plot(datasets, sorted_models, arr_norm.tolist(), metric_name + " (Normalized)", bar_path_norm, no_title=no_title)
     # Heatmap - pass display strings for mean±std annotation
-    heatmap_plot(datasets, sorted_models, sorted_plot_matrix, metric_name, heatmap_path, 
-                 normalize=False, display_strings=sorted_display_matrix, no_std=no_std)
+    heatmap_plot(datasets, sorted_models, sorted_plot_matrix, metric_name, heatmap_path,
+                 normalize=False, display_strings=sorted_display_matrix, no_std=no_std, no_title=no_title)
     # Normalized heatmap uses sorting based on normalized averages
-    heatmap_plot(datasets, sorted_models_norm, sorted_plot_matrix_norm, metric_name, heatmap_path_norm, 
-                 normalize=True, display_strings=sorted_display_matrix_norm, no_std=no_std)
+    heatmap_plot(datasets, sorted_models_norm, sorted_plot_matrix_norm, metric_name, heatmap_path_norm,
+                 normalize=True, display_strings=sorted_display_matrix_norm, no_std=no_std, no_title=no_title)
     print(f"Radar saved to {radar_path}")
     print(f"Radar (normalized) saved to {radar_path_norm}")
     print(f"Bar   saved to {bar_path}")
@@ -495,9 +503,10 @@ def main() -> None:
     ap.add_argument("--input", required=True, help="TSV file with metrics")
     ap.add_argument("--output_dir", default="plots", help="Directory for plots")
     ap.add_argument("--no_std", action="store_true", help="Do not display standard deviation in heatmap plots")
+    ap.add_argument("--no_title", action="store_true", help="Suppress the main title on every plot")
     args = ap.parse_args()
 
-    create_plots(Path(args.input), Path(args.output_dir), no_std=args.no_std)
+    create_plots(Path(args.input), Path(args.output_dir), no_std=args.no_std, no_title=args.no_title)
     print("Finished.")
 
 


### PR DESCRIPTION
Under autocast, the frozen base model emits bf16 hidden states while the vec2vec translator's Linear weights are loaded fp32, causing a dtype mismatch mid-forward. Cast base_state / base_vec to the translator's parameter dtype before passing into vec2vec_model.translate.