### PR TITLE
ESMC SAE workflows, estimator probes, and the FastPLMs SAE runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,14 @@ This is the standalone Synthyra Protify checkout. Keep its public training, eval
 - CLI, YAML, GUI, and cloud dispatch share the same `MainProcess` pipeline.
 - Keep heavy model and dataset loading lazy where the registries and factories are lazy.
 - `src/protify/fastplms/` is a vendored repository with its own guidance. Do not mix FastPLMs changes into a Protify task.
-- `--parallel_probe_runs` applies only to compatible pooled, sequence-level linear probes. Matrix or tokenwise probes, transformer probes, Lyra probes, PPI run-specific datasets, and full fine-tuning use the sequential fallback.
+- `--parallel_probe_runs` applies only to compatible pooled, sequence-level MLP probes. Matrix or tokenwise probes, transformer probes, Lyra probes, PPI run-specific datasets, and full fine-tuning use the sequential fallback.
+- A resolved model name carries everything that changes its embeddings. ESMC sparse autoencoder aliases expand to names such as `ESMC-300-SAE-l23-k64-c8192`, so the layer, sparsity, and codebook width reach the embedding cache filename and the results table without any separate cache key.
+- FastPLMs owns the sparse autoencoder runtime, through `ESMplusplusModel.load_sae_models` and `compute_sae=True`, which returns one sparse `(valid_tokens, codebook_dim)` tensor per attached layer. `src/protify/base_models/esmc_sae.py` owns only what is Protify's: the published-coverage registry, model-name resolution, pooling to one vector per protein, and the storage policy. Do not reimplement the SAE encoder here.
+- SAE models return one vector per sequence. They accept `max`, `mean`, and `sum` only, and reject `--matrix_embed`, because the dense per-residue codebook tensor does not fit the cache. Pooling drops the leading and trailing special tokens, matching the Biohub reference workflow.
+- Pair datasets swap protein A and B only on the training split, and only under `--random_pair_flipping`. Swapping a validation or test pair would make a reported score depend on the random state.
+- Coordinate-list blob storage is selected by the model, through `EsmcSaeForEmbedding.sparse_storage`, not per embedding. Every other model writes dense and pays nothing for the feature. bfloat16 keeps its own bit pattern under dtype code 3; code 1 is the older float16-byte encoding and is read but never written.
+- `probe_type` is normalized once in `ProbeArguments` and `ParallelProbeRunSpec`. `mlp` is the current name; `linear` is accepted because saved probe configs, exported repositories, and existing YAML carry it, and `MLPProbeConfig.model_type` stays `linear_probe`.
+- Estimator probes (`xgboost`, `lightgbm`, `random_forest`) run through `run_estimator_probes`, share the embedding cache and results table with the neural probes, and skip embedding standardization because it cannot change a tree's splits and would densify sparse features.
 
 ## Python Coding Standard
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ This is the standalone Synthyra Protify checkout. Keep its public training, eval
 - Coordinate-list blob storage is selected by the model, through `EsmcSaeForEmbedding.sparse_storage`, not per embedding. Every other model writes dense and pays nothing for the feature. bfloat16 keeps its own bit pattern under dtype code 3; code 1 is the older float16-byte encoding and is read but never written.
 - `probe_type` is normalized once in `ProbeArguments` and `ParallelProbeRunSpec`. `mlp` is the current name; `linear` is accepted because saved probe configs, exported repositories, and existing YAML carry it, and `MLPProbeConfig.model_type` stays `linear_probe`.
 - Estimator probes (`xgboost`, `lightgbm`, `random_forest`) run through `run_estimator_probes`, share the embedding cache and results table with the neural probes, and skip embedding standardization because it cannot change a tree's splits and would densify sparse features.
+- The shared metric functions read their input as raw logits, because neural probes produce logits: the single-label one softmaxes and the multi-label one sigmoids before thresholding at 0.5. `estimator_probe._predictions` therefore returns log probabilities and log odds, never the probabilities `predict_proba` gives back.
+- Matrix embeddings are cached with the leading and trailing special tokens, so a stored per-residue embedding has `len(seq) + 2` rows. Nothing may reshape one against `len(seq)`.
 
 ## Python Coding Standard
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,10 @@ For more details about supported models and datasets, including programmatic acc
 
 - **Multiple interfaces**: Run experiments via an intuitive GUI, CLI, or prepared YAML files
 - **Efficient embeddings**: Leverage fast and efficient embeddings from 46+ PLMs (ESM2, ESMC, E1, ProtBert, ProtT5, ANKH, GLM2, DPLM, DPLM2, DSM, AMPLIFY, CaLM, and more) via [FastPLMs](https://github.com/Synthyra/FastPLMs)
-- **Flexible model training**: Probe-only (frozen PLM), full fine-tuning, hybrid probing, LoRA via PEFT, and vectorized multi-seed linear probes
-- **Parallel probe sweeps**: Train many seeded pooled linear probes in one vectorized pass with `--parallel_probe_runs`, including run-specific deterministic shuffles and static preflight planning for workstation launches
+- **Sparse autoencoder features**: Read ESMC through the Biohub sparse autoencoders with `ESMC-300-SAE`, `ESMC-600-SAE`, or `ESMC-6B-SAE`, choosing any published layer, sparsity, and codebook width. FastPLMs runs the SAE and returns sparse per-residue features; Protify reduces them to one vector per protein and stores wide codebooks sparsely, so a 131072-wide codebook costs roughly a ninth of dense storage. See [models and embeddings](docs/models_and_embeddings.md)
+- **Estimator probes**: `--probe_type xgboost`, `lightgbm`, or `random_forest` fit gradient-boosted or forest models on pooled embeddings through the same pipeline, cache, and results table as the neural probes. Axis-aligned splits read sparse autoencoder features directly
+- **Flexible model training**: Probe-only (frozen PLM), full fine-tuning, hybrid probing, LoRA via PEFT, and vectorized multi-seed MLP probes
+- **Parallel probe sweeps**: Train many seeded pooled MLP probes in one vectorized pass with `--parallel_probe_runs`, including run-specific deterministic shuffles and static preflight planning for workstation launches
 - **Automated model selection**: Find optimal scikit-learn models for your data with LazyPredict, enhanced by automatic hyperparameter optimization
 - **Hyperparameter optimization**: Integrated Weights & Biases sweeps that conducts a hyperparameter search and trains the final version based on the best hyperparameters
 - **Complete reproducibility**: Every session generates a detailed log that can be used to reproduce your entire workflow
@@ -339,9 +341,9 @@ pip install -v -U git+https://github.com/facebookresearch/xformers.git@main#egg=
   Notes:
   - Pass your Hugging Face and W&B tokens in the GUI Info tab so remote runs can authenticate for gated model access, experiment tracking, and Hub uploads.
 
-  ### Parallel multi-seed linear probes
+  ### Parallel multi-seed MLP probes
 
-  When embeddings are already cached, pooled sequence-level linear probes can train many seeds together instead of launching one Hugging Face Trainer run per seed:
+  When embeddings are already cached, pooled sequence-level MLP probes can train many seeds together instead of launching one Hugging Face Trainer run per seed:
 
   ```bash
   python -m main --model_names ESM2-8 --data_names DeepLoc-2 --num_runs 8 --parallel_probe_runs --parallel_probe_batch_mode run_specific --parallel_probe_index_strategy permutation --parallel_probe_max_group_size 8
@@ -411,7 +413,7 @@ pip install -v -U git+https://github.com/facebookresearch/xformers.git@main#egg=
     Note: If you download embeddings, it will be faster to use the scikit model tab than the probe tab
   <img src="https://github.com/Gleghorn-Lab/Protify/blob/main/assets/example_workflow/5.PNG" width="500">
   
-  5.) Select which probe and configuration you would like. Here, we will use a simple linear probe, a type neural network. It is the **fastest** (by a large margin) but worst performing option (by a small margin usually).
+  5.) Select which probe and configuration you would like. Here, we will use a simple MLP probe, a small neural network. It is the **fastest** (by a large margin) but worst performing option (by a small margin usually).
   
   <img src="https://github.com/Gleghorn-Lab/Protify/blob/main/assets/example_workflow/6.PNG" width="500">
   
@@ -693,7 +695,7 @@ To run only CPU tests (no GPU required):
 docker run --rm -v "${PWD}":/workspace -w /workspace protify python -m pytest src/protify/testing_suite/ -v -m "not gpu and not slow"
 ```
 
-For vectorized multi-seed linear probe changes, run the focused Docker suite from `src/protify`:
+For vectorized multi-seed MLP probe changes, run the focused Docker suite from `src/protify`:
 
 ```bash
 docker run --rm --gpus all -v "${PWD}":/workspace -e PYTHONPATH=/workspace -w /workspace/src/protify protify python -m pytest testing_suite/test_parallel_probe_benchmark.py testing_suite/test_parallel_probe_batches.py testing_suite/test_parallel_probe_compare.py testing_suite/test_parallel_probe_hardware_monitor.py testing_suite/test_parallel_probe_launch_manifest_runner.py testing_suite/test_parallel_probe_plan.py testing_suite/test_parallel_linear_probe.py testing_suite/test_parallel_probe_logger.py testing_suite/test_parallel_probe_preflight.py testing_suite/test_trainer_arguments.py -v

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Results and logs go to `results/` and `logs/` by default. For full install optio
 | **Configuration** | All CLI argument groups, YAML config (base.yaml), merge behavior, model_names vs model_paths, full examples | [cli_and_config.md](cli_and_config.md) |
 | **Data** | DataArguments, supported datasets, data_dirs, loading flow, column normalization, translation flags, dataset classes | [data.md](data.md) |
 | **Models and embeddings** | Base models (model_names / model_paths), get_base_model and get_tokenizer, EmbeddingArguments, Embedder flow, pooling, SQL vs PTH | [models_and_embeddings.md](models_and_embeddings.md) |
-| **Probes and training** | Probe types (linear, transformer, lyra), ProbeArguments, TrainerArguments, training flows, vectorized multi-seed linear probes, preflight planning, validation, num_runs, save/export | [probes_and_training.md](probes_and_training.md) |
+| **Probes and training** | Probe types (mlp, transformer, lyra, xgboost, lightgbm, random_forest), ProbeArguments, TrainerArguments, training flows, vectorized multi-seed MLP probes, preflight planning, validation, num_runs, save/export | [probes_and_training.md](probes_and_training.md) |
 | **Model components** | For developers: attention, attention_utils, transformer, mlp; which probes use which | [model_components.md](model_components.md) |
 | **ProteinGym** | ProteinGymRunner, scoring methods, run_proteingym_zero_shot, CLI args, compare_scoring_methods, benchmark | [proteingym.md](proteingym.md) |
 | **Visualization** | create_plots (TSV format, six PNGs), regression vs classification metrics, ci_plots, CLI | [visualization.md](visualization.md) |

--- a/docs/cli_and_config.md
+++ b/docs/cli_and_config.md
@@ -68,7 +68,7 @@ The schema is defined by the union of [base.yaml](../src/protify/yamls/base.yaml
 | `--data_names` | list | [] | Dataset names (HuggingFace or preset e.g. standard_benchmark). |
 | `--data_dirs` | list | [] | Local split directories with train and valid/test aliases; accepts tabular files or labeled FASTA. |
 | `--aa_to_dna`, `--aa_to_rna`, `--dna_to_aa`, `--rna_to_aa`, `--codon_to_aa`, `--aa_to_codon` | flag | False | Sequence translation (only one may be True). |
-| `--random_pair_flipping` | flag | False | Random swap of paired inputs (e.g. PPI). |
+| `--random_pair_flipping` | flag | False | Randomly swap paired inputs (e.g. PPI) on the training split only. Validation and test keep the dataset order so a score does not depend on the random state. |
 | `--multi_column` | list | None | Sequence column names for multi-input tasks. |
 
 ### Base model
@@ -80,14 +80,18 @@ The schema is defined by the union of [base.yaml](../src/protify/yamls/base.yaml
 | `--model_types` | list | None | Type keywords for each path (esm2, custom, etc.). |
 | `--model_dtype` | choice | bf16 | fp32, fp16, bf16, float32, float16, bfloat16. |
 | `--use_xformers` | flag | False | Use xformers attention for AMPLIFY. |
+| `--sae_layer` | int | None | ESMC hidden-state layer the sparse autoencoder reads. Defaults to the depth layer each backbone publishes (23, 27, 60). |
+| `--sae_k` | choice | None | Active SAE features per residue: 16, 32, 64, 128, 256, 512. Defaults to 64. |
+| `--sae_codebook_dim` | choice | None | SAE codebook width, the embedding dimension per pooling type: 8192, 16384, 32768, 65536, 131072. Defaults to 8192. |
 
 ### Probe
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `--probe_type` | choice | linear | linear, transformer, lyra. |
+| `--probe_type` | choice | mlp | mlp, transformer, lyra, xgboost, lightgbm, random_forest. "linear" is the former name for mlp. |
 | `--tokenwise` | flag | False | Token-wise prediction. |
-| `--hidden_size` | int | 8192 | Hidden size for linear probe MLP. |
+| `--probe_n_jobs` | int | -1 | Workers for xgboost, lightgbm, and random_forest probes. |
+| `--hidden_size` | int | 8192 | Hidden size for the MLP probe. |
 | `--transformer_hidden_size` | int | 512 | Hidden size for transformer probe. |
 | `--dropout` | float | 0.2 | Dropout rate. |
 | `--n_layers` | int | 1 | Number of layers. |
@@ -163,7 +167,7 @@ The schema is defined by the union of [base.yaml](../src/protify/yamls/base.yaml
 | `--full_finetuning` | flag | False | Full model finetuning. |
 | `--hybrid_probe` | flag | False | Hybrid probe then finetune. |
 | `--num_runs` | int | 1 | Number of seeds; report mean and std. |
-| `--parallel_probe_runs` | flag | False | For eligible pooled linear probes, train all `--num_runs` seeds in one vectorized trainer pass. |
+| `--parallel_probe_runs` | flag | False | For eligible pooled MLP probes, train all `--num_runs` seeds in one vectorized trainer pass. |
 | `--parallel_probe_batch_mode` | choice | shared | With `--parallel_probe_runs`, use `shared` minibatches across runs or `run_specific` deterministic per-run training permutations. |
 | `--parallel_probe_index_strategy` | choice | permutation | With `--parallel_probe_batch_mode run_specific`, use materialized per-run `permutation` indices or memory-free deterministic `affine` bijections. |
 | `--parallel_probe_max_group_size` | int | None | Optional cap on seeds per vectorized probe bank; larger `--num_runs` values are chunked into multiple parallel Trainer invocations. |
@@ -254,7 +258,7 @@ model_names: [ESM2-8]
 # model_types: [...]
 
 # ProbeArguments
-probe_type: linear
+probe_type: mlp
 tokenwise: false
 # ...
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -103,11 +103,17 @@ Minimal probe-only run (one model, one dataset, two epochs):
 py -m src.protify.main --model_names ESM2-8 --data_names DeepLoc-2 --num_epochs 2
 ```
 
-Defaults:
+The reference config in `src/protify/yamls/base.yaml` runs the recommended stack instead: ESMC 300M read through its sparse autoencoder, max-pooled, into a gradient-boosted probe.
+
+```bash
+py -m src.protify.main --yaml_path src/protify/yamls/base.yaml --data_names DeepLoc-2
+```
+
+Command-line defaults:
 
 - `--log_dir logs`, `--results_dir results`, `--plots_dir plots`
 - `--embedding_save_dir embeddings`, `--model_save_dir weights`
-- Probe: linear; embeddings: mean pooling; no saving of embeddings unless you set `--save_embeddings`
+- Probe: mlp; embeddings: mean and variance pooling; no saving of embeddings unless you set `--save_embeddings`
 
 Results appear in `results/` (TSV of metrics) and `logs/` (session log). Plots are written to `plots/` after the run.
 

--- a/docs/hyperparameter_optimization.md
+++ b/docs/hyperparameter_optimization.md
@@ -13,7 +13,7 @@ When `--use_wandb_hyperopt` is set, the pipeline runs a W&B sweep over the param
 ## How it works
 
 1. **Sweep config** is loaded from `full_args.sweep_config_path` (default `yamls/sweep.yaml`). Required: `parameters` (W&B format). Optional: `early_terminate` (e.g. hyperband).
-2. Parameters are filtered by probe type and LoRA: only keys in `linear_probe_params` or `transformer_probe_params` (and optionally `lora_params`) are passed to the sweep; the rest are ignored for that run.
+2. Parameters are filtered by probe type and LoRA: only keys in `mlp_probe_params` or `transformer_probe_params` (and optionally `lora_params`) are passed to the sweep; the rest are ignored for that run.
 3. For each (model_name, data_name), embeddings are loaded, `num_labels` and `task_type` are set, and a **HyperoptModule** is created with the sweep config and a shared `results_list`.
 4. **W&B sweep** is created: `wandb.sweep(sweep, project, entity)` then `wandb.agent(sweep_id, function=hyperopt_module.objective, count=sweep_count)`.
 5. **HyperoptModule.objective()** is the W&B trial entry: `wandb.init(project, entity, config=sweep_config, reinit=True)`; `apply_config(wandb.config)`; optionally reload embeddings if `embedding_pooling_types` or `embedding_hidden_state_index` changed; `train_model(sweep_mode=True)`; select metric via `sweep_metric_cls` or `sweep_metric_reg` by task_type; log metrics to W&B; append to results_list; return metric value.
@@ -46,7 +46,7 @@ File: [src/protify/yamls/sweep.yaml](../src/protify/yamls/sweep.yaml).
   - LoRA: `lora_r`, `lora_alpha`, `lora_dropout`.
   - Trainer: `num_epochs`, `probe_batch_size`, `base_batch_size`, `probe_grad_accum`, `base_grad_accum`, `patience`, `seed`.
 
-Only parameters that are in the allowed sets (linear_probe_params, transformer_probe_params, lora_params, trainer_keys, embedding_keys) are applied; the rest are ignored for that probe type.
+Only parameters that are in the allowed sets (mlp_probe_params, transformer_probe_params, lora_params, trainer_keys, embedding_keys) are applied; the rest are ignored for that probe type.
 
 Example hidden-state sweep entry:
 

--- a/docs/model_components.md
+++ b/docs/model_components.md
@@ -10,7 +10,7 @@ The `model_components` package provides:
 
 - **Attention:** Rotary embeddings, multi-head attention with pluggable backends (flex, sdpa, kernels), and attention-based logits.
 - **Transformer:** A stack of transformer blocks (attention + SwiGLU FFN) used by the transformer probe.
-- **MLP:** SwiGLU and feed-forward helpers used in transformer blocks and in the linear probe (intermediate sizing).
+- **MLP:** SwiGLU and feed-forward helpers used in transformer blocks and in the MLP probe (intermediate sizing).
 
 Probes that use these components:
 
@@ -59,7 +59,7 @@ The **transformer probe** uses `Transformer` as the backbone above embeddings wi
 
 ## mlp.py
 
-- **intermediate_correction_fn(hidden_size, classifier_size):** Returns an intermediate dimension (used for classifier sizing in linear and transformer probes).
+- **intermediate_correction_fn(hidden_size, classifier_size):** Returns an intermediate dimension (used for classifier sizing in the MLP and transformer probes).
 - **SwiGLU:** Swish-gated linear unit module.
 - **swiglu_ln_ffn(hidden_size, expansion_ratio, dropout, use_bias):** LayerNorm + SwiGLU feed-forward used in TransformerBlock.
 

--- a/docs/models_and_embeddings.md
+++ b/docs/models_and_embeddings.md
@@ -118,6 +118,57 @@ The SQL path uses several optimizations to minimize the gap with in-memory dict 
 
 ---
 
+## ESMC sparse autoencoders
+
+A sparse autoencoder (SAE) reads one ESMC hidden state and re-expresses it over a wide codebook in which only `k` features are active per residue. Pooling those activations over the sequence gives one sparse, high-dimensional vector per protein, which is what makes SAE features easy to pool: max pooling asks "did this protein ever express feature j, and how strongly", and needs no learned pooler.
+
+Use them through the model names `ESMC-300-SAE`, `ESMC-600-SAE`, and `ESMC-6B-SAE`:
+
+```bash
+py -m src.protify.main --model_names ESMC-300-SAE --data_names solubility \
+  --probe_type xgboost --embedding_pooling_types max --save_embeddings --sql
+```
+
+### Choosing a checkpoint
+
+A bare alias resolves to the layer at 75% depth, the only layer Biohub publishes across the whole sparsity and width grid, at `k=64` and codebook width 8192. Override with `--sae_layer`, `--sae_k`, and `--sae_codebook_dim`. The resolved name carries the full identity, for example `ESMC-300-SAE-l23-k64-c8192`, and that name is what appears in embedding cache filenames, the results table, and plots. Two variants therefore never share a cache.
+
+Published coverage, from `ESMC_SAE_COVERAGE` in [esmc_sae.py](../src/protify/base_models/esmc_sae.py):
+
+| Backbone | Layers | Depth layer | Grid at the depth layer | Every other layer |
+|----------|--------|-------------|-------------------------|-------------------|
+| ESMC-300 | 0 to 30 | 23 | k in {16, 32, 64, 128, 256, 512} times codebook in {8192, 16384, 32768, 65536, 131072} | k=64, codebook 16384 only |
+| ESMC-600 | 0 to 36 | 27 | same grid | k=64, codebook 16384 only |
+| ESMC-6B | 0 to 80 | 60 | same grid | k=64, codebook 16384 or 131072 |
+
+Asking for a combination Biohub does not publish raises and names the valid options rather than silently substituting one. Layer indices match `--embedding_hidden_state_index`: index `i` is the input to block `i`, and index `n_layers` is the final normalized state.
+
+### Pooling and storage
+
+FastPLMs owns the SAE runtime. `ESMplusplusModel.load_sae_models` attaches the Biohub checkpoint, and a forward pass with `compute_sae=True` returns one sparse COO tensor of shape `(valid_tokens, codebook_dim)` covering the whole batch. Protify reduces that tensor to one vector per protein with a single scatter, dropping the leading and trailing special tokens the way the Biohub reference workflow does.
+
+SAE models accept `max`, `mean`, and `sum` in `--embedding_pooling_types`. Several pooling types concatenate as usual, so `max mean` yields `2 * w` features. Other pooling types, and `--matrix_embed`, raise: a single residue at codebook width 131072 costs 256 KiB dense.
+
+Embeddings go to a coordinate-list blob format when the SAE they came from is sparse enough to pay for it, decided once from the checkpoint by `EsmcSaeForEmbedding.sparse_storage`. Every other model stores dense and pays nothing for the feature.
+
+The deciding quantity is the active fraction `k / codebook_dim`, not either number alone. Per residue exactly `k` of `codebook_dim` features are active whatever the sequence length. Pooling unions those sets across residues, so pooled density does grow with length, and how fast it grows tracks the active fraction. Measured max-pooled density at codebook 16384, from short proteins to past 1200 residues:
+
+| k | active fraction | pooled density | stored |
+|---|---|---|---|
+| 16 | 0.10% | 1.7% to 5.1% | coordinates |
+| 64 | 0.39% | 9.7% to 34.2% | coordinates |
+| 256 | 1.56% | 19.6% to 56.5% | dense |
+
+Only k=256 crosses the roughly 45% break-even. The threshold sits between the k=64 and k=256 active fractions, and independently reproduces the codebook 8192 result at k=64, where the 16208 `gold-ppi` proteins split almost evenly between the formats and dense was the better single choice.
+
+At the widths where coordinates win, they win by a lot: 200 proteins at codebook 65536 stored 3.2 MB against 26.2 MB dense, an eight-fold reduction, with every protein in coordinate form.
+
+### Normalization statistics
+
+Biohub normalizes activations as `(features / max) * idf`. FastPLMs exposes this as `normalize_sae=True` and reads the `max` and `idf` buffers from the checkpoint, defaulting both to ones for shards that never trained them. Protify embeds unnormalized, matching the Biohub reference PPI workflow. Normalization is a per-feature positive rescaling, so it cannot change which features max pooling selects, only their magnitudes; it is not currently exposed as a Protify flag because it would have to reach the embedding cache filename to keep the two variants separable.
+
+---
+
 ## Pooling types
 
 Common values for `embedding_pooling_types` (and probe-side `probe_pooling_types` where applicable):

--- a/docs/probes_and_training.md
+++ b/docs/probes_and_training.md
@@ -1,12 +1,12 @@
 # Probes and Training
 
-This page documents probe types (linear, transformer, lyra), `ProbeArguments` and `get_probe`, `TrainerArguments` and `TrainerMixin`, and the training flows: probe-only (`run_nn_probes`), full finetuning, hybrid, and scikit. It also covers `num_runs` aggregation and model save/export.
+This page documents probe types (mlp, transformer, lyra, xgboost, lightgbm, random_forest), `ProbeArguments` and `get_probe`, `TrainerArguments` and `TrainerMixin`, and the training flows: probe-only (`run_nn_probes`), full finetuning, hybrid, and scikit. It also covers `num_runs` aggregation and model save/export.
 
 ---
 
 ## Overview
 
-A **probe** is a trainable head on top of (frozen or trainable) base model embeddings. Protify supports three probe types: **linear** (MLP), **transformer**, and **lyra**. Training can be probe-only (default), full base-model finetuning, or hybrid (train probe then finetune base+probe). The scikit path uses precomputed embeddings with sklearn-style models. All probes share a common forward API (embeddings, attention_mask, optional labels) and return loss, logits, and optional hidden_states/attentions.
+A **probe** is a trainable head on top of (frozen or trainable) base model embeddings. Protify supports three neural probe types, **mlp**, **transformer**, and **lyra**, plus the estimator probes **xgboost**, **lightgbm**, and **random_forest**. Training can be probe-only (default), full base-model finetuning, or hybrid (train probe then finetune base+probe). The scikit path uses precomputed embeddings with sklearn-style models. All probes share a common forward API (embeddings, attention_mask, optional labels) and return loss, logits, and optional hidden_states/attentions.
 
 ---
 
@@ -34,11 +34,33 @@ flowchart LR
 
 | Type | Sequence | Token | Description |
 |------|----------|-------|-------------|
-| **linear** | Yes | No | MLP on pooled embeddings. Fastest; good baseline. |
+| **mlp** | Yes | No | Feed-forward stack on pooled embeddings. Fastest neural probe; good baseline. |
 | **transformer** | Yes | Yes | Transformer stack + pooler/classifier. Uses [model_components](model_components.md) Transformer. |
 | **lyra** | Yes | Yes | S4/Lyra probe; no shared model_components. |
+| **xgboost** | Yes | No | Gradient-boosted trees on pooled embeddings. |
+| **lightgbm** | Yes | No | Gradient-boosted trees, leaf-wise growth. |
+| **random_forest** | Yes | No | Bagged trees; no early stopping. |
 
-**When to use:** Linear for speed and baselines; transformer for better accuracy when compute allows; lyra for sequence modeling alternatives. Token-wise is for residue-level tasks (e.g. secondary structure).
+**When to use:** `mlp` for speed and baselines; `transformer` for better accuracy when compute allows; `lyra` for sequence modeling alternatives; `xgboost` and its siblings for sparse features such as max-pooled sparse autoencoder codebooks, where axis-aligned splits read individual features directly. Token-wise is for residue-level tasks (e.g. secondary structure).
+
+`mlp` was called `linear` before it grew hidden layers. `--probe_type linear` still selects it, and saved probe configs, exported repositories, and existing YAML keep working. The serialized `model_type` on `MLPProbeConfig` remains `linear_probe` so published probe repositories still load.
+
+### Estimator probes
+
+`xgboost`, `lightgbm`, and `random_forest` run through `run_estimator_probes` in [main.py](../src/protify/main.py), which shares the embedding cache, results table, plots, and `num_runs` seed aggregation with the neural probes. They differ from the `--use_scikit` path, which searches across many sklearn models; an estimator probe fits one model with the defaults in [estimator_probe.py](../src/protify/probes/estimator_probe.py).
+
+Two behaviors are specific to them:
+
+- **No embedding standardization.** A per-feature shift and scale cannot change which splits a tree can express, and centering would turn a sparse feature matrix dense. `prepare_scikit_dataset(..., standardize=False)` skips it.
+- **Defaults selected on measurement.** The xgboost entry in `ESTIMATOR_DEFAULTS` was chosen by validation MCC over seeds 42 to 44, fitting `ESMC-300-SAE-l23-k64-c8192` max-pooled features on the `solubility` dataset (55536 train rows, 8192 features). It reaches 0.4864 validation MCC where XGBoost's library defaults reach 0.4458, a gap around ten times the 0.0044 seed standard deviation. That selection predates the move to the FastPLMs SAE runtime, whose residue standardization raised the same features from 23.7% to 36.6% non-zero, and the defaults were not reselected afterwards. The gain comes from many low-learning-rate trees under early stopping; sweeping `colsample_bytree` from 0.1 to 1.0 moved validation MCC by under 0.01. The lightgbm and random_forest entries follow the same shape but were not separately measured.
+
+Override any hyperparameter with `--scikit_model_args`, a JSON object:
+
+```bash
+py -m src.protify.main --model_names ESMC-300-SAE --data_names gold-ppi \
+  --probe_type xgboost --embedding_pooling_types max \
+  --scikit_model_args '{"max_depth": 10, "learning_rate": 0.03}'
+```
 
 ---
 
@@ -48,10 +70,10 @@ Defined in [get_probe.py](../src/protify/probes/get_probe.py). Key attributes (C
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `probe_type` | str | linear | linear, transformer, lyra. |
+| `probe_type` | str | mlp | mlp, transformer, lyra, xgboost, lightgbm, random_forest. "linear" is the former name for mlp. |
 | `tokenwise` | bool | False | Token-wise prediction. |
 | `input_size` | int | 960 | Input dimension (set from embedding size). |
-| `hidden_size` | int | 8192 | Hidden size for linear probe MLP. |
+| `hidden_size` | int | 8192 | Hidden size for the MLP probe. |
 | `transformer_hidden_size` | int | 512 | Hidden size for transformer. |
 | `dropout` | float | 0.2 | Dropout. |
 | `num_labels` | int | 2 | Number of classes (set from data). |
@@ -78,7 +100,7 @@ Defined in [get_probe.py](../src/protify/probes/get_probe.py). Key attributes (C
 ## get_probe and rebuild_probe_from_saved_config
 
 - **get_probe(args: ProbeArguments)**
-  Returns a probe instance: `LinearProbe`, `TransformerForSequenceClassification`, `TransformerForTokenClassification`, or the Lyra variants. Config is built from `args.__dict__` (with `hidden_size` overridden by `transformer_hidden_size` for transformer).
+  Returns a probe instance: `MLPProbe`, `TransformerForSequenceClassification`, `TransformerForTokenClassification`, or the Lyra variants. Config is built from `args.__dict__` (with `hidden_size` overridden by `transformer_hidden_size` for transformer).
 
 - **rebuild_probe_from_saved_config(probe_type, tokenwise, probe_config)**
   Rebuilds the same probe classes from a saved config dict (e.g. when loading a packaged model).
@@ -117,7 +139,7 @@ Defined in [trainers.py](../src/protify/probes/trainers.py).
 | `num_workers` | int | 0 | DataLoader workers. |
 | `make_plots` | bool | True | Generate CI plots. |
 | `num_runs` | int | 1 | Number of seeds; aggregate mean and std. |
-| `parallel_probe_runs` | bool | False | For pooled sequence-level linear probes, train `num_runs` seeded probes in one vectorized pass. |
+| `parallel_probe_runs` | bool | False | For pooled sequence-level MLP probes, train `num_runs` seeded probes in one vectorized pass. |
 | `parallel_probe_batch_mode` | str | shared | `shared` reuses each training minibatch across runs; `run_specific` uses deterministic per-run training permutations. |
 | `parallel_probe_index_strategy` | str | permutation | For `run_specific`, `permutation` materializes exact per-run shuffled indices; `affine` uses deterministic memory-free bijections. |
 | `parallel_probe_max_group_size` | int | None | Optional cap on seeded probes per vectorized bank; larger `num_runs` are chunked into multiple parallel Trainer invocations. |
@@ -149,11 +171,11 @@ Calling `trainer_args(probe=True)` or `trainer_args(probe=False)` returns Huggin
 
 When `num_runs > 1`, the trainer runs training `num_runs` times with different seeds, collects metrics (e.g. test loss, spearman), and computes mean and std. The best run (by test loss or selected metric) is used for optional CI plots and reporting. Metrics logged include `*_mean` and `*_std` variants.
 
-Set `parallel_probe_runs=True` (CLI: `--parallel_probe_runs`) to use the vectorized path for pooled, sequence-level linear probes. This builds `ParallelLinearProbe` banks with an explicit run dimension over independently initialized parameters, uses batched matrix multiplication across runs, shares each minibatch across runs by default, sums per-run losses during training to preserve each run's gradient scale, averages per-run loss for evaluation/early stopping, aggregates metrics across all seeds, and exports the best run back to a normal `LinearProbe`. Matrix/tokenwise probes, transformer probes, Lyra probes, and full fine-tuning continue to use the sequential path.
+Set `parallel_probe_runs=True` (CLI: `--parallel_probe_runs`) to use the vectorized path for pooled, sequence-level MLP probes. This builds `ParallelLinearProbe` banks with an explicit run dimension over independently initialized parameters, uses batched matrix multiplication across runs, shares each minibatch across runs by default, sums per-run losses during training to preserve each run's gradient scale, averages per-run loss for evaluation/early stopping, aggregates metrics across all seeds, and exports the best run back to a normal `MLPProbe`. Matrix/tokenwise probes, transformer probes, Lyra probes, and full fine-tuning continue to use the sequential path.
 
 During HuggingFace validation evaluation, the parallel path also emits per-run metric keys such as `eval_run_0_loss`, `eval_run_0_accuracy`, and `eval_run_1_loss` through `compute_metrics`. Early stopping and checkpoint selection still use the aggregate bank-level `eval_loss`, so these per-run keys are observability and parity checks rather than independent checkpoint selectors. The explicit post-training valid/test prediction pass computes `parallel_probe_valid_run_metrics` and `parallel_probe_test_run_metrics` itself and disables redundant HuggingFace `compute_metrics` during `predict`.
 
-The planning layer in [parallel_probe_plan.py](../src/protify/probes/parallel_probe_plan.py) represents each candidate run as a `ParallelProbeRunSpec` and groups only runs with matching model, dataset, embedding cache, trainer settings, batch mode, and linear probe architecture. `ParallelProbeExecutionPlan` summarizes a larger model universe / dataset universe / probe universe sweep, including vectorized groups, sequential fallbacks, trainer invocation reduction, and a largest-parallel-first execution order. `estimate_parallel_probe_plan()` adds static trainable-state estimates: linear-probe parameter bytes, gradient bytes, and AdamW moment bytes for each vectorized bank. When a caller provides planned batch and dataset sizes, it also estimates per-batch activation/logit bytes and materialized run-specific permutation-index bytes. The Trainer executes the compatible seed groups for one model/dataset pair; `parallel_probe_max_group_size` can split a large seed set into multiple vectorized banks so workstation runs can sweep the utilization and memory tradeoff without returning to fully sequential training. `parallel_probe_training_state_budget_gb` derives this group-size cap automatically from trainable state only; `parallel_probe_estimated_peak_budget_gb` includes trainable state, batch activations, and materialized run-specific index bytes. If multiple caps are set, the smallest cap is used.
+The planning layer in [parallel_probe_plan.py](../src/protify/probes/parallel_probe_plan.py) represents each candidate run as a `ParallelProbeRunSpec` and groups only runs with matching model, dataset, embedding cache, trainer settings, batch mode, and MLP probe architecture. `ParallelProbeExecutionPlan` summarizes a larger model universe / dataset universe / probe universe sweep, including vectorized groups, sequential fallbacks, trainer invocation reduction, and a largest-parallel-first execution order. `estimate_parallel_probe_plan()` adds static trainable-state estimates: MLP probe parameter bytes, gradient bytes, and AdamW moment bytes for each vectorized bank. When a caller provides planned batch and dataset sizes, it also estimates per-batch activation/logit bytes and materialized run-specific permutation-index bytes. The Trainer executes the compatible seed groups for one model/dataset pair; `parallel_probe_max_group_size` can split a large seed set into multiple vectorized banks so workstation runs can sweep the utilization and memory tradeoff without returning to fully sequential training. `parallel_probe_training_state_budget_gb` derives this group-size cap automatically from trainable state only; `parallel_probe_estimated_peak_budget_gb` includes trainable state, batch activations, and materialized run-specific index bytes. If multiple caps are set, the smallest cap is used.
 
 Use `parallel_probe_batch_mode='shared'` for the highest reuse: every run sees the same minibatch order while keeping independent weights and losses. Use `parallel_probe_batch_mode='run_specific'` to wrap the training dataset with [ParallelRunDataset](../src/protify/probes/parallel_probe_batches.py), which feeds run-specific pooled batches shaped `[batch, runs, dim]` with labels shaped `[batch, runs]` or `[batch, runs, labels]`. Validation and test batches remain shared across runs so per-run metrics compare on the same examples. The `run_specific` mode is limited to pooled non-PPI embedding datasets. Its default `parallel_probe_index_strategy='permutation'` materializes exact per-run shuffled indices as compact tensors; `parallel_probe_index_strategy='affine'` uses deterministic memory-free bijections for very large corpora where storing one permutation per run would be too expensive. When the base dataset exposes in-memory pooled embeddings or a two-tensor `TensorDataset`, `ParallelRunDataset` builds a tensor cache and uses vectorized `index_select` instead of calling the base dataset once per seed per sample. This is the recommended path for pre-embedded probe sweeps.
 
@@ -325,7 +347,7 @@ Production export uses the same probe rebuild API so that the packaged artifact 
 ### Linear probe (default)
 
 ```bash
-py -m src.protify.main --model_names ESM2-8 --data_names DeepLoc-2 --probe_type linear
+py -m src.protify.main --model_names ESM2-8 --data_names DeepLoc-2 --probe_type mlp
 ```
 
 ### Transformer probe with more layers

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,7 +25,7 @@ Tests are under [src/protify/testing_suite/](../src/protify/testing_suite/). The
 | **test_seed_utils.py** | `set_global_seed` / `get_global_seed`, reproducibility (torch, numpy, random), `seed_worker`, `dataloader_generator`. |
 | **test_lazy_predict.py** | LazyClassifier and LazyRegressor fit, models, predictions, provide_models. |
 | **test_packaged_probe_export.py** | Linear and transformer probe save/load roundtrip via PackagedProbeModel, PPI inference with/without token_type_ids. |
-| **test_parallel_linear_probe.py** | Vectorized multi-seed linear probe behavior, exported single-run parity, shared and run-specific batches, per-run metrics, ensemble metrics, gradient clipping, chunking, and budget-derived group sizing. |
+| **test_parallel_linear_probe.py** | Vectorized multi-seed MLP probe behavior, exported single-run parity, shared and run-specific batches, per-run metrics, ensemble metrics, gradient clipping, chunking, and budget-derived group sizing. |
 | **test_parallel_probe_batches.py** | `ParallelRunDataset` deterministic per-run indexing, affine index strategy, tensor-cache fast paths, and collator shapes. |
 | **test_parallel_probe_plan.py** | Static grouping and resource estimates for model/dataset/probe/seed universes. |
 | **test_parallel_probe_preflight.py** | No-training launch-manifest generation, embedding prerequisites, execution waves, GPU placement metadata, validation templates, and helper-only `--num_labels` behavior. |

--- a/src/protify/base_models/esmc_sae.py
+++ b/src/protify/base_models/esmc_sae.py
@@ -1,0 +1,345 @@
+"""ESMC sparse autoencoder adapters over the FastPLMs hidden-state SAE contract.
+
+FastPLMs owns the SAE runtime: `ESMplusplusModel.load_sae_models` reads a Biohub
+repository and `compute_sae=True` returns one sparse `(n, c)` tensor per attached layer,
+covering the valid tokens of the whole batch. This module owns what is Protify's instead:
+which checkpoints the registry offers, how a model name encodes one, how the per-residue
+features pool into one vector per protein, and whether that vector is stored sparsely.
+
+Model names carry the full checkpoint identity, for example
+`ESMC-300-SAE-l23-k64-c8192`, so embedding cache filenames, result tables, and plots
+separate SAE variants without any further plumbing. A bare `ESMC-300-SAE` resolves to the
+depth layer each backbone publishes, at the default sparsity and codebook width.
+"""
+
+import re
+import torch
+import torch.nn as nn
+
+from dataclasses import dataclass
+from typing import Any
+
+from .utils import ensure_fastplms_submodule_on_path, load_fastplms_model
+
+
+ensure_fastplms_submodule_on_path()
+
+from fastplms.models.esm_plusplus.modeling_esm_plusplus import ESMplusplusModel
+
+from .esmc import ESMTokenizerWrapper, get_esmc_tokenizer
+
+
+@dataclass(frozen=True)
+class EsmcSaeCoverage:
+    """Which sparse autoencoders Biohub publishes for one ESMC backbone."""
+
+    biohub_name: str
+    model_path: str
+    hidden_size: int
+    num_hidden_layers: int
+    # Biohub trains every sparsity and codebook width at this layer only.
+    depth_layer: int
+    # Codebook widths published at every other layer, always at ALL_LAYER_K.
+    all_layer_codebook_dims: tuple[int, ...]
+
+
+# Protify display prefix to the published coverage. `biohub_name` and `model_path` are the
+# SAE repository stem and the ESM++ backbone checkpoint the SAE reads from.
+ESMC_SAE_COVERAGE: dict[str, EsmcSaeCoverage] = {
+    'ESMC-300': EsmcSaeCoverage('ESMC-300M', 'Synthyra/ESMplusplus_small', 960, 30, 23, (16384,)),
+    'ESMC-600': EsmcSaeCoverage('ESMC-600M', 'Synthyra/ESMplusplus_large', 1152, 36, 27, (16384,)),
+    'ESMC-6B': EsmcSaeCoverage('ESMC-6B', 'Synthyra/ESMplusplus_6B', 2560, 80, 60, (16384, 131072)),
+}
+
+SAE_K_VALUES = (16, 32, 64, 128, 256, 512)
+SAE_CODEBOOK_DIMS = (8192, 16384, 32768, 65536, 131072)
+# Sparsity Biohub trains at every layer other than the depth layer.
+ALL_LAYER_K = 64
+
+DEFAULT_SAE_K = 64
+DEFAULT_SAE_CODEBOOK_DIM = 8192
+
+# Pooling names this adapter reduces the sparse feature tensor with. Anything else would
+# need the dense (b, l, c) activation tensor, which is the cost sparse output avoids.
+SAE_POOLING_TYPES = ('max', 'mean', 'sum')
+
+# Active feature fraction, k / codebook_dim, below which pooled features stay sparse
+# enough across the whole length range to store as coordinates. See
+# EsmcSaeForEmbedding.sparse_storage for the measurements this sits between.
+SPARSE_ACTIVE_FRACTION = 0.005
+
+_NAME_PATTERN = re.compile(
+    r'^(?P<backbone>ESMC-(?:300|600|6B))-SAE'
+    r'(?:-l(?P<layer>\d+)-k(?P<k>\d+)-c(?P<codebook>\d+))?$',
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class EsmcSaeSelection:
+    """One published Biohub sparse autoencoder checkpoint."""
+
+    backbone: str
+    layer: int
+    k: int
+    codebook_dim: int
+
+    @property
+    def repository(self) -> str:
+        coverage = ESMC_SAE_COVERAGE[self.backbone]
+        return (
+            f'biohub/{coverage.biohub_name}-sae'
+            f'-layer{self.layer}-k{self.k}-codebook{self.codebook_dim}'
+        )
+
+
+def resolve_sae_selection(backbone: str, layer: int, k: int, codebook_dim: int) -> EsmcSaeSelection:
+    """Validate one checkpoint request against what Biohub publishes."""
+    coverage = ESMC_SAE_COVERAGE[backbone]
+    if not 0 <= layer <= coverage.num_hidden_layers:
+        raise ValueError(
+            f'{backbone} has hidden states 0 to {coverage.num_hidden_layers}; '
+            f'--sae_layer {layer} is outside that range.'
+        )
+    if k not in SAE_K_VALUES:
+        raise ValueError(f'--sae_k {k} is not published; Biohub trains {list(SAE_K_VALUES)}.')
+    if codebook_dim not in SAE_CODEBOOK_DIMS:
+        raise ValueError(
+            f'--sae_codebook_dim {codebook_dim} is not published; '
+            f'Biohub trains {list(SAE_CODEBOOK_DIMS)}.'
+        )
+
+    if layer != coverage.depth_layer:
+        # Away from the depth layer Biohub publishes one sparsity and a short width list.
+        if k != ALL_LAYER_K or codebook_dim not in coverage.all_layer_codebook_dims:
+            raise ValueError(
+                f'{backbone} layer {layer} only publishes k={ALL_LAYER_K} at codebook widths '
+                f'{list(coverage.all_layer_codebook_dims)}. Layer {coverage.depth_layer} '
+                f'publishes every sparsity and width.'
+            )
+
+    return EsmcSaeSelection(backbone, layer, k, codebook_dim)
+
+
+def is_sae_model_name(name: str) -> bool:
+    return _NAME_PATTERN.match(name) is not None
+
+
+def resolve_sae_model_name(
+    name: str,
+    sae_layer: int | None = None,
+    sae_k: int | None = None,
+    sae_codebook_dim: int | None = None,
+) -> str:
+    """Expand a bare SAE alias into its fully qualified name.
+
+    A fully qualified name is returned unchanged, and conflicting overrides raise rather
+    than being dropped, so a name always describes the checkpoint that produced it.
+    """
+    match = _NAME_PATTERN.match(name)
+    if match is None:
+        raise ValueError(f"{name!r} is not an ESMC SAE model name.")
+
+    backbone = _canonical_backbone(match.group('backbone'))
+    requested = {'sae_layer': sae_layer, 'sae_k': sae_k, 'sae_codebook_dim': sae_codebook_dim}
+
+    if match.group('layer') is not None:
+        declared = {
+            'sae_layer': int(match.group('layer')),
+            'sae_k': int(match.group('k')),
+            'sae_codebook_dim': int(match.group('codebook')),
+        }
+        conflicts = {
+            key: (value, declared[key])
+            for key, value in requested.items()
+            if value is not None and value != declared[key]
+        }
+        if conflicts:
+            details = '; '.join(f"--{k}={v[0]} contradicts {v[1]}" for k, v in conflicts.items())
+            raise ValueError(f"{name} already fixes its SAE checkpoint, but {details}.")
+
+        selection = resolve_sae_selection(
+            backbone, declared['sae_layer'], declared['sae_k'], declared['sae_codebook_dim']
+        )
+    else:
+        selection = resolve_sae_selection(
+            backbone,
+            sae_layer if sae_layer is not None else ESMC_SAE_COVERAGE[backbone].depth_layer,
+            sae_k if sae_k is not None else DEFAULT_SAE_K,
+            sae_codebook_dim if sae_codebook_dim is not None else DEFAULT_SAE_CODEBOOK_DIM,
+        )
+
+    return f'{backbone}-SAE-l{selection.layer}-k{selection.k}-c{selection.codebook_dim}'
+
+
+def parse_sae_model_name(name: str) -> EsmcSaeSelection:
+    """Read a fully qualified SAE model name back into its checkpoint."""
+    match = _NAME_PATTERN.match(name)
+    if match is None or match.group('layer') is None:
+        raise ValueError(
+            f"{name!r} is not a fully qualified ESMC SAE model name. Expected the form "
+            f"ESMC-300-SAE-l23-k64-c8192, which resolve_sae_model_name produces."
+        )
+
+    return resolve_sae_selection(
+        _canonical_backbone(match.group('backbone')),
+        int(match.group('layer')),
+        int(match.group('k')),
+        int(match.group('codebook')),
+    )
+
+
+def _canonical_backbone(prefix: str) -> str:
+    for candidate in ESMC_SAE_COVERAGE:
+        if candidate.lower() == prefix.lower():
+            return candidate
+
+    raise ValueError(f"Unknown ESMC SAE backbone prefix {prefix!r}.")
+
+
+class EsmcSaeForEmbedding(nn.Module):
+    """ESM++ backbone with a Biohub sparse autoencoder read off one hidden state.
+
+    Returns pooled codebook features rather than residue embeddings, because the dense
+    per-residue activation tensor is too large to store at these widths.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        selection: EsmcSaeSelection,
+        pooling_types: tuple[str, ...] = ('max',),
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        unsupported = [name for name in pooling_types if name not in SAE_POOLING_TYPES]
+        if unsupported:
+            raise ValueError(
+                f"SAE embeddings support pooling types {SAE_POOLING_TYPES}; received "
+                f"{unsupported}. Other pooling would need the dense (b, l, c) activation "
+                f"tensor, which is {selection.codebook_dim} wide per residue."
+            )
+
+        self.esm = load_fastplms_model(ESMplusplusModel, model_path, dtype=dtype)
+        self.esm.load_sae_models(selection.repository, [selection.layer])
+        self.selection = selection
+        self.pooling_types = tuple(pooling_types)
+        self.sae_key = f'layer{selection.layer}'
+
+    @property
+    def sparse_storage(self) -> bool:
+        """Whether these features belong in the coordinate-list blob format.
+
+        Per residue exactly `k` of `codebook_dim` features are active, whatever the
+        sequence length. Pooling unions those sets across residues, so pooled density
+        does grow with length, and how fast it grows tracks the active fraction
+        `k / codebook_dim` rather than either number alone.
+
+        Measured max-pooled density at codebook 16384, from short proteins to past 1200
+        residues: 1.7% to 5.1% at k=16, 9.7% to 34.2% at k=64, and 19.6% to 56.5% at
+        k=256. Only the last crosses the roughly 45% break-even. The threshold below sits
+        between the k=64 and k=256 active fractions, and independently reproduces the
+        codebook 8192 result at k=64, where measured storage split almost evenly between
+        the two formats and dense was the better single choice.
+        """
+        return self.selection.k / self.selection.codebook_dim <= SPARSE_ACTIVE_FRACTION
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        output_attentions: bool | None = None,
+        hidden_state_index: int = -1,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        # input_ids: (b, l); attention_mask: (b, l) or None
+        if output_attentions:
+            raise ValueError("SAE embeddings do not expose attentions, so 'parti' pooling is out.")
+        if hidden_state_index not in (-1, self.selection.layer):
+            raise ValueError(
+                f"{self.selection.repository} reads layer {self.selection.layer}; "
+                f"--embedding_hidden_state_index {hidden_state_index} contradicts it."
+            )
+
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)  # (b, l)
+
+        model_output = self.esm(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            compute_sae=True,
+        )
+        # FastPLMs returns valid tokens of the whole batch flattened, in row-major order.
+        features = model_output.sae_outputs[self.sae_key].coalesce()  # sparse (n, c)
+        token_counts = attention_mask.sum(dim=1).to(torch.long)  # (b,)
+
+        pooled = [
+            self._pool(features, token_counts, name)  # (b, c)
+            for name in self.pooling_types
+        ]
+        return torch.cat(pooled, dim=-1)  # (b, p * c), p = len(pooling_types)
+
+    def _pool(
+        self, features: torch.Tensor, token_counts: torch.Tensor, pooling: str
+    ) -> torch.Tensor:
+        """Reduce sparse per-residue codebook features to one vector per sequence.
+
+        The leading and trailing special tokens are dropped, matching the Biohub reference
+        workflow: those positions carry activations that describe no residue.
+        """
+        # features: sparse (n, c) over the batch's valid tokens; token_counts: (b,)
+        batch_size = int(token_counts.shape[0])  # b
+        codebook_dim = int(features.shape[1])  # c
+        device = features.device
+
+        owner = torch.repeat_interleave(  # (n,) sequence index of each valid token
+            torch.arange(batch_size, device=device), token_counts
+        )
+        sequence_start = torch.cumsum(token_counts, dim=0) - token_counts  # (b,)
+        position = torch.arange(int(owner.shape[0]), device=device) - sequence_start[owner]  # (n,)
+        residue_rows = (position > 0) & (position < (token_counts[owner] - 1))  # (n,)
+
+        indices = features.indices()  # (2, nnz)
+        values = features.values().float()  # (nnz,)
+        keep = residue_rows[indices[0]]  # (nnz,)
+        flat_positions = owner[indices[0][keep]] * codebook_dim + indices[1][keep]  # (kept,)
+
+        pooled = torch.zeros(batch_size * codebook_dim, dtype=torch.float32, device=device)
+        reduce = 'amax' if pooling == 'max' else 'sum'
+        pooled.scatter_reduce_(0, flat_positions, values[keep], reduce=reduce, include_self=True)
+        pooled = pooled.reshape(batch_size, codebook_dim)  # (b, c)
+
+        if pooling == 'mean':
+            # Two special tokens were dropped, so a length-2 input has no residues to average.
+            residue_counts = (token_counts - 2).clamp(min=1).to(pooled.dtype)  # (b,)
+            pooled = pooled / residue_counts.unsqueeze(-1)  # (b, c)
+
+        return pooled  # (b, c)
+
+
+def build_esmc_sae_model(
+    preset: str,
+    masked_lm: bool = False,
+    dtype: torch.dtype | None = None,
+    model_path: str | None = None,
+    pooling_types: tuple[str, ...] | None = ('max',),
+    **kwargs: Any,
+) -> tuple[nn.Module, ESMTokenizerWrapper]:
+    if masked_lm:
+        raise ValueError("SAE models produce codebook features, not masked-language-model logits.")
+
+    selection = parse_sae_model_name(preset)
+
+    if pooling_types is None:
+        raise ValueError(
+            f"{preset} cannot produce matrix embeddings. One residue of codebook "
+            f"{selection.codebook_dim} costs {4 * selection.codebook_dim // 1024} KiB "
+            f"dense, so per-residue SAE features do not fit the embedding cache. Drop "
+            f"--matrix_embed and pool with --embedding_pooling_types max."
+        )
+
+    backbone_path = model_path or ESMC_SAE_COVERAGE[selection.backbone].model_path
+    model = EsmcSaeForEmbedding(
+        backbone_path, selection, pooling_types=tuple(pooling_types), dtype=dtype
+    ).eval()
+    return model, get_esmc_tokenizer(preset)

--- a/src/protify/base_models/esmc_sae.py
+++ b/src/protify/base_models/esmc_sae.py
@@ -204,6 +204,11 @@ class EsmcSaeForEmbedding(nn.Module):
     per-residue activation tensor is too large to store at these widths.
     """
 
+    # Reduction happens in forward, over the sparse feature tensor. Embedder reads this to
+    # skip building a Pooler, whose names are validated against dense (b, l, d) activations
+    # and so overlap SAE_POOLING_TYPES without matching it.
+    pools_internally = True
+
     def __init__(
         self,
         model_path: str,

--- a/src/protify/base_models/get_base_models.py
+++ b/src/protify/base_models/get_base_models.py
@@ -4,9 +4,22 @@ from typing import List, Optional
 from .supported_models import currently_supported_models, standard_models, experimental_models
 
 
+def _expand_sae_name(name: str, sae_layer: Optional[int], sae_k: Optional[int], sae_codebook_dim: Optional[int]) -> str:
+    """Resolve an ESMC SAE alias to a name that names its checkpoint, leaving others alone.
+
+    The resolved name flows into embedding cache filenames and result tables, so an SAE
+    variant never shares a cache with a different layer, sparsity, or codebook width.
+    """
+    if '-sae' not in name.lower():
+        return name
+
+    from .esmc_sae import resolve_sae_model_name
+    return resolve_sae_model_name(name, sae_layer, sae_k, sae_codebook_dim)
+
+
 @dataclass
 class BaseModelArguments:
-    def __init__(self, model_names: Optional[List[str]] = None, model_paths: Optional[List[str]] = None, model_types: Optional[List[str]] = None, model_dtype: object = None, **kwargs) -> None:
+    def __init__(self, model_names: Optional[List[str]] = None, model_paths: Optional[List[str]] = None, model_types: Optional[List[str]] = None, model_dtype: object = None, sae_layer: Optional[int] = None, sae_k: Optional[int] = None, sae_codebook_dim: Optional[int] = None, **kwargs) -> None:
         if model_paths is not None:
             assert model_types is not None, "model_types is required when model_paths is provided."
             assert len(model_paths) == len(model_types), f"model_paths ({len(model_paths)}) and model_types ({len(model_types)}) must have the same length."
@@ -23,6 +36,9 @@ class BaseModelArguments:
                 self.model_names = model_names
             self._model_types = None
             self._model_paths = None
+            self.model_names = [
+                _expand_sae_name(name, sae_layer, sae_k, sae_codebook_dim) for name in self.model_names
+            ]
         self.model_dtype = model_dtype
 
     def model_entries(self):
@@ -39,10 +55,13 @@ class BaseModelArguments:
                 yield name, name, None
 
 
-def get_base_model(model_name: str, masked_lm: bool = False, dtype=None, model_path: str = None):
+def get_base_model(model_name: str, masked_lm: bool = False, dtype=None, model_path: str = None, pooling_types=None):
     if 'random' in model_name.lower():
         from .random import build_random_model
         return build_random_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
+    elif '-sae' in model_name.lower():
+        from .esmc_sae import build_esmc_sae_model
+        return build_esmc_sae_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path, pooling_types=pooling_types)
     elif 'esm2' in model_name.lower() and model_name.lower().count('esm2') == 1:
         from .esm2 import build_esm2_model
         return build_esm2_model(model_name, masked_lm=masked_lm, dtype=dtype, model_path=model_path)
@@ -94,7 +113,13 @@ def get_base_model(model_name: str, masked_lm: bool = False, dtype=None, model_p
 
 
 def get_base_model_for_training(model_name: str, tokenwise: bool = False, num_labels: int = None, hybrid: bool = False, dtype=None, model_path: str = None):
-    if 'esm2' in model_name.lower() or 'dsm' in model_name.lower():
+    if '-sae' in model_name.lower():
+        raise ValueError(
+            f"{model_name} reads a frozen sparse autoencoder off ESMC hidden states, so it "
+            f"has no trainable path. Drop --full_finetuning and --hybrid_probe, or train the "
+            f"plain backbone with --model_names {model_name.split('-SAE')[0]}."
+        )
+    elif 'esm2' in model_name.lower() or 'dsm' in model_name.lower():
         from .esm2 import get_esm2_for_training
         return get_esm2_for_training(model_name, tokenwise, num_labels, hybrid, dtype=dtype, model_path=model_path)
     elif 'esmc' in model_name.lower():

--- a/src/protify/base_models/supported_models.py
+++ b/src/protify/base_models/supported_models.py
@@ -15,6 +15,13 @@ all_presets_with_paths = {
     'ESMC-300': 'Synthyra/ESMplusplus_small',
     'ESMC-600': 'Synthyra/ESMplusplus_large',
     'ESMC-6B': 'Synthyra/ESMplusplus_6B',
+    # ESMC sparse autoencoders (from esmc_sae.py). These aliases expand to a fully
+    # qualified name such as ESMC-300-SAE-l23-k64-c8192; the path here is the ESM++
+    # backbone the SAE reads, since the codebook weights come from a separate Biohub
+    # repository that resolve_sae_selection picks.
+    'ESMC-300-SAE': 'Synthyra/ESMplusplus_small',
+    'ESMC-600-SAE': 'Synthyra/ESMplusplus_large',
+    'ESMC-6B-SAE': 'Synthyra/ESMplusplus_6B',
     # E1 models (from e1.py)
     'E1-150': 'Synthyra/Profluent-E1-150M',
     'E1-300': 'Synthyra/Profluent-E1-300M',
@@ -79,6 +86,9 @@ currently_supported_models = [
     'ESMC-300',
     'ESMC-600',
     'ESMC-6B',
+    'ESMC-300-SAE',
+    'ESMC-600-SAE',
+    'ESMC-6B-SAE',
     'E1-150',
     'E1-300',
     'E1-600',

--- a/src/protify/data/data_mixin.py
+++ b/src/protify/data/data_mixin.py
@@ -54,6 +54,24 @@ SPLIT_ALIASES = {
 }
 
 
+def _to_numpy(embedding: torch.Tensor) -> np.ndarray:
+    """Convert an embedding to numpy, widening bfloat16 which numpy cannot represent."""
+    if embedding.dtype == torch.bfloat16:
+        embedding = embedding.float()
+    return embedding.numpy()
+
+
+def _as_rows(embedding: np.ndarray, seq: str, full: bool) -> np.ndarray:
+    """Reshape one embedding into rows so concatenation yields an (n, d) matrix.
+
+    The SQL backend returns a pooled vector at its stored rank, (d,), while the PTH
+    backend already returns (1, d). Normalizing here keeps both paths building the same
+    matrix.
+    """
+    # embedding: (d,) or (1, d) pooled, or (l, d) per-residue
+    return embedding.reshape(len(seq), -1) if full else embedding.reshape(1, -1)
+
+
 
 @dataclass
 class DataArguments:
@@ -215,7 +233,7 @@ class DataMixin:
         fallback_shape = (1, -1) if not self._full else (len(seq), -1)
         embedding = embedding_blob_to_tensor(raw, fallback_shape=fallback_shape)
         if not cast_to_torch:
-            embedding = embedding.numpy()
+            embedding = _to_numpy(embedding)
         return embedding
 
     def _select_from_pth(self, emb_dict: Dict[str, torch.Tensor], seq: str, cast_to_np: bool = False) -> torch.Tensor:
@@ -223,7 +241,7 @@ class DataMixin:
         if self._full:
             embedding = embedding.reshape(len(seq), -1)
         if cast_to_np:
-            embedding = embedding.numpy()
+            embedding = _to_numpy(embedding)
         return embedding
 
     def _labels_to_numpy(self, labels: list) -> np.ndarray:
@@ -1095,30 +1113,30 @@ class DataMixin:
             with sqlite3.connect(save_path) as conn:
                 c = conn.cursor()
                 for seq in train_seqs:
-                    embedding = self._select_from_sql(c, seq, cast_to_torch=False)
+                    embedding = _as_rows(self._select_from_sql(c, seq, cast_to_torch=False), seq, self._full)
                     train_array.append(embedding)
 
                 for seq in valid_seqs:
-                    embedding = self._select_from_sql(c, seq, cast_to_torch=False)
+                    embedding = _as_rows(self._select_from_sql(c, seq, cast_to_torch=False), seq, self._full)
                     valid_array.append(embedding)
 
                 for seq in test_seqs:
-                    embedding = self._select_from_sql(c, seq, cast_to_torch=False)
+                    embedding = _as_rows(self._select_from_sql(c, seq, cast_to_torch=False), seq, self._full)
                     test_array.append(embedding)
         else:
             filename = get_embedding_filename(model_name, self._full, pooling_types, 'pth', hidden_state_index)
             save_path = os.path.join(save_dir, filename)
             emb_dict = torch.load(save_path)
             for seq in train_seqs:
-                embedding = self._select_from_pth(emb_dict, seq, cast_to_np=True)
+                embedding = _as_rows(self._select_from_pth(emb_dict, seq, cast_to_np=True), seq, self._full)
                 train_array.append(embedding)
                 
             for seq in valid_seqs:
-                embedding = self._select_from_pth(emb_dict, seq, cast_to_np=True)
+                embedding = _as_rows(self._select_from_pth(emb_dict, seq, cast_to_np=True), seq, self._full)
                 valid_array.append(embedding)
 
             for seq in test_seqs:
-                embedding = self._select_from_pth(emb_dict, seq, cast_to_np=True)
+                embedding = _as_rows(self._select_from_pth(emb_dict, seq, cast_to_np=True), seq, self._full)
                 test_array.append(embedding)
             del emb_dict
 
@@ -1146,7 +1164,11 @@ class DataMixin:
             valid_seqs_b,
             test_seqs_a,
             test_seqs_b,
+            flip_train_pairs: bool = False,
         ):
+        # Interaction is symmetric but concatenation is not, so swapping A and B augments
+        # the training set. Validation and test keep the dataset order, because swapping
+        # there would make a score depend on the random state rather than the model.
         save_dir = self.embedding_args.embedding_save_dir
         train_array, valid_array, test_array = [], [], []
         pooling_types = self.embedding_args.pooling_types
@@ -1157,42 +1179,40 @@ class DataMixin:
             with sqlite3.connect(save_path) as conn:
                 c = conn.cursor()
                 for seq_a, seq_b in zip(train_seqs_a, train_seqs_b):
-                    seq_a, seq_b = self._random_order(seq_a, seq_b)
-                    embedding_a = self._select_from_sql(c, seq_a, cast_to_torch=False)
-                    embedding_b = self._select_from_sql(c, seq_b, cast_to_torch=False)
+                    if flip_train_pairs:
+                        seq_a, seq_b = self._random_order(seq_a, seq_b)
+                    embedding_a = _as_rows(self._select_from_sql(c, seq_a, cast_to_torch=False), seq_a, self._full)
+                    embedding_b = _as_rows(self._select_from_sql(c, seq_b, cast_to_torch=False), seq_b, self._full)
                     train_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
                 for seq_a, seq_b in zip(valid_seqs_a, valid_seqs_b):
-                    seq_a, seq_b = self._random_order(seq_a, seq_b)
-                    embedding_a = self._select_from_sql(c, seq_a, cast_to_torch=False)
-                    embedding_b = self._select_from_sql(c, seq_b, cast_to_torch=False)
+                    embedding_a = _as_rows(self._select_from_sql(c, seq_a, cast_to_torch=False), seq_a, self._full)
+                    embedding_b = _as_rows(self._select_from_sql(c, seq_b, cast_to_torch=False), seq_b, self._full)
                     valid_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
                 for seq_a, seq_b in zip(test_seqs_a, test_seqs_b):
-                    seq_a, seq_b = self._random_order(seq_a, seq_b)
-                    embedding_a = self._select_from_sql(c, seq_a, cast_to_torch=False)
-                    embedding_b = self._select_from_sql(c, seq_b, cast_to_torch=False)
+                    embedding_a = _as_rows(self._select_from_sql(c, seq_a, cast_to_torch=False), seq_a, self._full)
+                    embedding_b = _as_rows(self._select_from_sql(c, seq_b, cast_to_torch=False), seq_b, self._full)
                     test_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
         else:
             filename = get_embedding_filename(model_name, self._full, pooling_types, 'pth', hidden_state_index)
             save_path = os.path.join(save_dir, filename)
             emb_dict = torch.load(save_path)
             for seq_a, seq_b in zip(train_seqs_a, train_seqs_b):
-                seq_a, seq_b = self._random_order(seq_a, seq_b)
-                embedding_a = self._select_from_pth(emb_dict, seq_a, cast_to_np=True)
-                embedding_b = self._select_from_pth(emb_dict, seq_b, cast_to_np=True)
+                if flip_train_pairs:
+                    seq_a, seq_b = self._random_order(seq_a, seq_b)
+                embedding_a = _as_rows(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), seq_a, self._full)
+                embedding_b = _as_rows(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), seq_b, self._full)
                 train_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
             for seq_a, seq_b in zip(valid_seqs_a, valid_seqs_b):
-                seq_a, seq_b = self._random_order(seq_a, seq_b)
-                embedding_a = self._select_from_pth(emb_dict, seq_a, cast_to_np=True)
-                embedding_b = self._select_from_pth(emb_dict, seq_b, cast_to_np=True)
+                embedding_a = _as_rows(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), seq_a, self._full)
+                embedding_b = _as_rows(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), seq_b, self._full)
                 valid_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
             for seq_a, seq_b in zip(test_seqs_a, test_seqs_b):
-                seq_a, seq_b = self._random_order(seq_a, seq_b)
-                embedding_a = self._select_from_pth(emb_dict, seq_a, cast_to_np=True)
-                embedding_b = self._select_from_pth(emb_dict, seq_b, cast_to_np=True)
+                embedding_a = _as_rows(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), seq_a, self._full)
+                embedding_b = _as_rows(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), seq_b, self._full)
                 test_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
             del emb_dict
 
@@ -1211,7 +1231,18 @@ class DataMixin:
         print_message(f'Test: {test_array.shape}')
         return train_array, valid_array, test_array
 
-    def prepare_scikit_dataset(self, model_name, dataset):
+    def prepare_scikit_dataset(
+        self, model_name, dataset, standardize: bool = True, flip_train_pairs: bool = False
+    ):
+        """Materialize pooled embeddings and labels as numpy arrays.
+
+        `standardize` exists for axis-aligned learners: a per-feature shift and scale
+        cannot change which splits a decision tree can express, and centering would turn
+        a sparse SAE feature matrix dense.
+
+        `flip_train_pairs` carries --random_pair_flipping into the paired builder and is
+        ignored for single-sequence datasets.
+        """
         train_set, valid_set, test_set, _, label_type, ppi = dataset
 
         if ppi:
@@ -1223,6 +1254,7 @@ class DataMixin:
                 list(valid_set['SeqB']),
                 list(test_set['SeqA']),
                 list(test_set['SeqB']),
+                flip_train_pairs=flip_train_pairs,
             )
         else:
             X_train, X_valid, X_test = self.build_vector_numpy_dataset_from_embeddings(
@@ -1232,7 +1264,7 @@ class DataMixin:
                 list(test_set['seqs']),
             )
 
-        embedding_scaler = self.embedding_args.embedding_scaler
+        embedding_scaler = self.embedding_args.embedding_scaler and standardize
         assert isinstance(embedding_scaler, bool), f"Invalid embedding_scaler: {embedding_scaler}"
         if not self._full and embedding_scaler:
             print_message('Fitting StandardScaler on scikit training embeddings')

--- a/src/protify/data/data_mixin.py
+++ b/src/protify/data/data_mixin.py
@@ -61,15 +61,17 @@ def _to_numpy(embedding: torch.Tensor) -> np.ndarray:
     return embedding.numpy()
 
 
-def _as_rows(embedding: np.ndarray, seq: str, full: bool) -> np.ndarray:
-    """Reshape one embedding into rows so concatenation yields an (n, d) matrix.
+def _as_row(embedding: np.ndarray, full: bool) -> np.ndarray:
+    """Reduce one cached embedding to a single row, so concatenation yields (n, d).
 
-    The SQL backend returns a pooled vector at its stored rank, (d,), while the PTH
-    backend already returns (1, d). Normalizing here keeps both paths building the same
-    matrix.
+    The SQL backend returns a pooled vector at its stored rank, (d,), while the PTH backend
+    already returns (1, d). Matrix caches instead hold (l, d) per residue, where l counts
+    the stored tokens including the leading and trailing special tokens, so l is len(seq)+2
+    rather than len(seq). These learners take one vector per sequence, so a matrix averages
+    over its own rows rather than being reshaped against the sequence length.
     """
     # embedding: (d,) or (1, d) pooled, or (l, d) per-residue
-    return embedding.reshape(len(seq), -1) if full else embedding.reshape(1, -1)
+    return embedding.mean(axis=0, keepdims=True) if full else embedding.reshape(1, -1)
 
 
 
@@ -237,9 +239,11 @@ class DataMixin:
         return embedding
 
     def _select_from_pth(self, emb_dict: Dict[str, torch.Tensor], seq: str, cast_to_np: bool = False) -> torch.Tensor:
-        embedding = emb_dict[seq].reshape(1, -1)
-        if self._full:
-            embedding = embedding.reshape(len(seq), -1)
+        # Matrix caches store (l, d) with the special tokens kept, so l is not len(seq);
+        # only the pooled case has a shape worth asserting here.
+        embedding = emb_dict[seq]
+        if not self._full:
+            embedding = embedding.reshape(1, -1)
         if cast_to_np:
             embedding = _to_numpy(embedding)
         return embedding
@@ -1113,41 +1117,37 @@ class DataMixin:
             with sqlite3.connect(save_path) as conn:
                 c = conn.cursor()
                 for seq in train_seqs:
-                    embedding = _as_rows(self._select_from_sql(c, seq, cast_to_torch=False), seq, self._full)
+                    embedding = _as_row(self._select_from_sql(c, seq, cast_to_torch=False), self._full)
                     train_array.append(embedding)
 
                 for seq in valid_seqs:
-                    embedding = _as_rows(self._select_from_sql(c, seq, cast_to_torch=False), seq, self._full)
+                    embedding = _as_row(self._select_from_sql(c, seq, cast_to_torch=False), self._full)
                     valid_array.append(embedding)
 
                 for seq in test_seqs:
-                    embedding = _as_rows(self._select_from_sql(c, seq, cast_to_torch=False), seq, self._full)
+                    embedding = _as_row(self._select_from_sql(c, seq, cast_to_torch=False), self._full)
                     test_array.append(embedding)
         else:
             filename = get_embedding_filename(model_name, self._full, pooling_types, 'pth', hidden_state_index)
             save_path = os.path.join(save_dir, filename)
             emb_dict = torch.load(save_path)
             for seq in train_seqs:
-                embedding = _as_rows(self._select_from_pth(emb_dict, seq, cast_to_np=True), seq, self._full)
+                embedding = _as_row(self._select_from_pth(emb_dict, seq, cast_to_np=True), self._full)
                 train_array.append(embedding)
                 
             for seq in valid_seqs:
-                embedding = _as_rows(self._select_from_pth(emb_dict, seq, cast_to_np=True), seq, self._full)
+                embedding = _as_row(self._select_from_pth(emb_dict, seq, cast_to_np=True), self._full)
                 valid_array.append(embedding)
 
             for seq in test_seqs:
-                embedding = _as_rows(self._select_from_pth(emb_dict, seq, cast_to_np=True), seq, self._full)
+                embedding = _as_row(self._select_from_pth(emb_dict, seq, cast_to_np=True), self._full)
                 test_array.append(embedding)
             del emb_dict
 
-        train_array = np.concatenate(train_array, axis=0)
-        valid_array = np.concatenate(valid_array, axis=0)
-        test_array = np.concatenate(test_array, axis=0)
-        
-        if self._full: # average over the length of the sequence
-            train_array = np.mean(train_array, axis=1)
-            valid_array = np.mean(valid_array, axis=1)
-            test_array = np.mean(test_array, axis=1)
+        # _as_row already averaged any per-residue matrix, so every element is (1, d).
+        train_array = np.concatenate(train_array, axis=0)  # (n_train, d)
+        valid_array = np.concatenate(valid_array, axis=0)  # (n_valid, d)
+        test_array = np.concatenate(test_array, axis=0)  # (n_test, d)
 
         print_message('Numpy dataset shapes')
         print_message(f'Train: {train_array.shape}')
@@ -1181,18 +1181,18 @@ class DataMixin:
                 for seq_a, seq_b in zip(train_seqs_a, train_seqs_b):
                     if flip_train_pairs:
                         seq_a, seq_b = self._random_order(seq_a, seq_b)
-                    embedding_a = _as_rows(self._select_from_sql(c, seq_a, cast_to_torch=False), seq_a, self._full)
-                    embedding_b = _as_rows(self._select_from_sql(c, seq_b, cast_to_torch=False), seq_b, self._full)
+                    embedding_a = _as_row(self._select_from_sql(c, seq_a, cast_to_torch=False), self._full)
+                    embedding_b = _as_row(self._select_from_sql(c, seq_b, cast_to_torch=False), self._full)
                     train_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
                 for seq_a, seq_b in zip(valid_seqs_a, valid_seqs_b):
-                    embedding_a = _as_rows(self._select_from_sql(c, seq_a, cast_to_torch=False), seq_a, self._full)
-                    embedding_b = _as_rows(self._select_from_sql(c, seq_b, cast_to_torch=False), seq_b, self._full)
+                    embedding_a = _as_row(self._select_from_sql(c, seq_a, cast_to_torch=False), self._full)
+                    embedding_b = _as_row(self._select_from_sql(c, seq_b, cast_to_torch=False), self._full)
                     valid_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
                 for seq_a, seq_b in zip(test_seqs_a, test_seqs_b):
-                    embedding_a = _as_rows(self._select_from_sql(c, seq_a, cast_to_torch=False), seq_a, self._full)
-                    embedding_b = _as_rows(self._select_from_sql(c, seq_b, cast_to_torch=False), seq_b, self._full)
+                    embedding_a = _as_row(self._select_from_sql(c, seq_a, cast_to_torch=False), self._full)
+                    embedding_b = _as_row(self._select_from_sql(c, seq_b, cast_to_torch=False), self._full)
                     test_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
         else:
             filename = get_embedding_filename(model_name, self._full, pooling_types, 'pth', hidden_state_index)
@@ -1201,29 +1201,25 @@ class DataMixin:
             for seq_a, seq_b in zip(train_seqs_a, train_seqs_b):
                 if flip_train_pairs:
                     seq_a, seq_b = self._random_order(seq_a, seq_b)
-                embedding_a = _as_rows(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), seq_a, self._full)
-                embedding_b = _as_rows(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), seq_b, self._full)
+                embedding_a = _as_row(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), self._full)
+                embedding_b = _as_row(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), self._full)
                 train_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
             for seq_a, seq_b in zip(valid_seqs_a, valid_seqs_b):
-                embedding_a = _as_rows(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), seq_a, self._full)
-                embedding_b = _as_rows(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), seq_b, self._full)
+                embedding_a = _as_row(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), self._full)
+                embedding_b = _as_row(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), self._full)
                 valid_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
 
             for seq_a, seq_b in zip(test_seqs_a, test_seqs_b):
-                embedding_a = _as_rows(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), seq_a, self._full)
-                embedding_b = _as_rows(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), seq_b, self._full)
+                embedding_a = _as_row(self._select_from_pth(emb_dict, seq_a, cast_to_np=True), self._full)
+                embedding_b = _as_row(self._select_from_pth(emb_dict, seq_b, cast_to_np=True), self._full)
                 test_array.append(np.concatenate([embedding_a, embedding_b], axis=-1))
             del emb_dict
 
-        train_array = np.concatenate(train_array, axis=0)
-        valid_array = np.concatenate(valid_array, axis=0)
-        test_array = np.concatenate(test_array, axis=0)
-        
-        if self._full: # average over the length of the sequence
-            train_array = np.mean(train_array, axis=1)
-            valid_array = np.mean(valid_array, axis=1)
-            test_array = np.mean(test_array, axis=1)
+        # Each row is protein A concatenated with protein B, both already one vector each.
+        train_array = np.concatenate(train_array, axis=0)  # (n_train, 2 * d)
+        valid_array = np.concatenate(valid_array, axis=0)  # (n_valid, 2 * d)
+        test_array = np.concatenate(test_array, axis=0)  # (n_test, 2 * d)
 
         print_message('Numpy dataset shapes')
         print_message(f'Train: {train_array.shape}')

--- a/src/protify/embedder.py
+++ b/src/protify/embedder.py
@@ -335,11 +335,14 @@ class Embedder:
         os.makedirs(self.embedding_save_dir, exist_ok=True)
         model = embedding_model.to(self.device).eval()
         sparse_storage = getattr(model, "sparse_storage", False)
+        # SAE models reduce inside the encoder and return (b, p * c), so a Pooler here would
+        # never be called, and would reject the names only they accept, such as 'sum'.
+        pools_internally = getattr(model, "pools_internally", False)
         dynamic = self.padding == 'longest'
         model = maybe_compile(model, dynamic=dynamic)
         device = self.device
         collate_fn = build_collator(tokenizer, padding=self.padding, max_length=self.max_length)
-        if self.matrix_embed:
+        if self.matrix_embed or pools_internally:
             pooler = None
         else:
             print_message(f'Pooling types: {self.pooling_types}')
@@ -476,11 +479,12 @@ class Embedder:
             )
             model_obj = model_obj.to(device).eval()
             sparse_storage = getattr(model_obj, "sparse_storage", False)
+            pools_internally = getattr(model_obj, "pools_internally", False)
             dynamic = self.padding == 'longest'
             model_obj = maybe_compile(model_obj, dynamic=dynamic)
             collate_fn = build_collator(tokenizer, padding=self.padding, max_length=self.max_length)
 
-            if self.matrix_embed:
+            if self.matrix_embed or pools_internally:
                 pooler = None
             else:
                 pooler = Pooler(self.pooling_types)

--- a/src/protify/embedder.py
+++ b/src/protify/embedder.py
@@ -334,6 +334,7 @@ class Embedder:
             embeddings_dict: Dict[str, torch.Tensor]) -> Optional[Dict[str, torch.Tensor]]:
         os.makedirs(self.embedding_save_dir, exist_ok=True)
         model = embedding_model.to(self.device).eval()
+        sparse_storage = getattr(model, "sparse_storage", False)
         dynamic = self.padding == 'longest'
         model = maybe_compile(model, dynamic=dynamic)
         device = self.device
@@ -398,19 +399,15 @@ class Embedder:
 
             with torch.autocast(device.type, dtype=self.embed_dtype, enabled=self.autocast):
                 if 'parti' in self.pooling_types:
-                    try:
-                        residue_embeddings, attentions = model(
-                            **batch,
-                            output_attentions=True,
-                            **hidden_kwargs,
-                        )
-                        embeddings = _get_embeddings(residue_embeddings, attention_mask=attention_mask, attentions=attentions).cpu()
-                    except Exception as e:
-                        print_message(f"Error in parti pooling: {e}\nDefaulting to mean pooling")
-                        self.pooling_types = ['mean']
-                        pooler = Pooler(self.pooling_types)
-                        residue_embeddings = model(**batch, **hidden_kwargs)
-                        embeddings = _get_embeddings(residue_embeddings, attention_mask=attention_mask).cpu()
+                    # A failure here used to switch the whole run to mean pooling, which
+                    # changed the embedding width partway through a cache and left the
+                    # filename claiming 'parti'. Let it raise instead.
+                    residue_embeddings, attentions = model(
+                        **batch,
+                        output_attentions=True,
+                        **hidden_kwargs,
+                    )
+                    embeddings = _get_embeddings(residue_embeddings, attention_mask=attention_mask, attentions=attentions).cpu()
                 else:
                     residue_embeddings = model(**batch, **hidden_kwargs)
                     embeddings = _get_embeddings(residue_embeddings, attention_mask=attention_mask).cpu()
@@ -420,9 +417,9 @@ class Embedder:
                 if self.matrix_embed:
                     batch_rows = []
                     for seq, emb, mask in zip(seqs, embeddings, attention_mask.cpu()):
-                        batch_rows.append((seq, tensor_to_embedding_blob(emb[mask.bool()])))
+                        batch_rows.append((seq, tensor_to_embedding_blob(emb[mask.bool()], sparse=sparse_storage)))
                 else:
-                    blobs = batch_tensor_to_blobs(embeddings)
+                    blobs = batch_tensor_to_blobs(embeddings, sparse=sparse_storage)
                     batch_rows = list(zip(seqs, blobs))
                 sql_writer.write_batch(batch_rows)
             else:
@@ -471,8 +468,14 @@ class Embedder:
         def _worker(rank: int, shard: List[str]) -> None:
             torch.cuda.set_device(rank)
             device = torch.device(f'cuda:{rank}')
-            model_obj, tokenizer = get_base_model(dispatch_name, dtype=self.model_dtype, model_path=model_path)
+            model_obj, tokenizer = get_base_model(
+                dispatch_name,
+                dtype=self.model_dtype,
+                model_path=model_path,
+                pooling_types=None if self.matrix_embed else self.pooling_types,
+            )
             model_obj = model_obj.to(device).eval()
+            sparse_storage = getattr(model_obj, "sparse_storage", False)
             dynamic = self.padding == 'longest'
             model_obj = maybe_compile(model_obj, dynamic=dynamic)
             collate_fn = build_collator(tokenizer, padding=self.padding, max_length=self.max_length)
@@ -542,9 +545,9 @@ class Embedder:
                         if self.matrix_embed:
                             batch_rows = []
                             for seq, emb, mask in zip(seqs, embeddings, attention_mask.cpu()):
-                                batch_rows.append((seq, tensor_to_embedding_blob(emb[mask.bool()])))
+                                batch_rows.append((seq, tensor_to_embedding_blob(emb[mask.bool()], sparse=sparse_storage)))
                         else:
-                            blobs = batch_tensor_to_blobs(embeddings)
+                            blobs = batch_tensor_to_blobs(embeddings, sparse=sparse_storage)
                             batch_rows = list(zip(seqs, blobs))
                         worker_sql_writer.write_batch(batch_rows)
                     else:
@@ -595,7 +598,14 @@ class Embedder:
                     to_embed, save_path, dispatch_name, model_path, embeddings_dict,
                 )
             else:
-                model, tokenizer = get_base_model(dispatch_name, dtype=self.model_dtype, model_path=model_path)
+                # SAE models fuse pooling into their encoder pass, so they need the
+                # pooling choice up front and return pooled vectors directly.
+                model, tokenizer = get_base_model(
+                    dispatch_name,
+                    dtype=self.model_dtype,
+                    model_path=model_path,
+                    pooling_types=None if self.matrix_embed else self.pooling_types,
+                )
                 return self._embed_sequences(to_embed, save_path, model, tokenizer, embeddings_dict)
         else:
             print_message(f"No sequences to embed with {model_name}")

--- a/src/protify/gui.py
+++ b/src/protify/gui.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 from base_models.get_base_models import BaseModelArguments, standard_models
 from data.supported_datasets import supported_datasets, standard_data_benchmark, internal_datasets
 from embedder import EmbeddingArguments
+from probes.estimator_probe import is_estimator_probe
 from probes.get_probe import ProbeArguments
 from probes.trainers import TrainerArguments
 from main import MainProcess
@@ -457,14 +458,14 @@ class GUI(MainProcess):
     def build_probe_tab(self):
         # Probe Type
         ttk.Label(self.probe_tab, text="Probe Type:").grid(row=0, column=0, padx=10, pady=5, sticky="w")
-        self.settings_vars["probe_type"] = tk.StringVar(value="linear")
+        self.settings_vars["probe_type"] = tk.StringVar(value="mlp")
         combo_probe = ttk.Combobox(
             self.probe_tab,
             textvariable=self.settings_vars["probe_type"],
-            values=["linear", "transformer", "lyra"]
+            values=["mlp", "transformer", "lyra", "xgboost", "lightgbm", "random_forest"]
         )
         combo_probe.grid(row=0, column=1, padx=10, pady=5)
-        self.add_help_button(self.probe_tab, 0, 2, "Type of probe architecture to use (linear, transformer, or lyra).")
+        self.add_help_button(self.probe_tab, 0, 2, "Probe to train on the embeddings: mlp, transformer, lyra, xgboost, lightgbm, or random_forest.")
 
         # Tokenwise
         ttk.Label(self.probe_tab, text="Tokenwise:").grid(row=1, column=0, padx=10, pady=5, sticky="w")
@@ -648,7 +649,7 @@ class GUI(MainProcess):
         self.settings_vars["hybrid_probe"] = tk.BooleanVar(value=False)
         check_hybrid_probe = ttk.Checkbutton(self.trainer_tab, variable=self.settings_vars["hybrid_probe"])
         check_hybrid_probe.grid(row=0, column=1, padx=10, pady=5, sticky="w")
-        self.add_help_button(self.trainer_tab, 0, 2, "Whether to use hybrid probe (combines neural and linear probes).")
+        self.add_help_button(self.trainer_tab, 0, 2, "Whether to use hybrid probe (trains the base model together with the probe).")
 
         # Full finetuning checkbox
         ttk.Label(self.trainer_tab, text="Full Finetuning:").grid(row=1, column=0, padx=10, pady=5, sticky="w")
@@ -1237,6 +1238,10 @@ class GUI(MainProcess):
             "embed_dtype": self.settings_vars["embed_dtype"].get(),
             "sql": self.settings_vars["sql"].get(),
             "probe_type": self.settings_vars["probe_type"].get(),
+            "probe_n_jobs": -1,
+            "sae_layer": None,
+            "sae_k": None,
+            "sae_codebook_dim": None,
             "tokenwise": self.settings_vars["tokenwise"].get(),
             "hidden_size": self.settings_vars["hidden_size"].get(),
 
@@ -1558,6 +1563,7 @@ class GUI(MainProcess):
         
         # Gather settings from variables
         self.full_args.probe_type = self.settings_vars["probe_type"].get()
+        self.full_args.probe_n_jobs = getattr(self.full_args, "probe_n_jobs", -1)
         self.full_args.tokenwise = self.settings_vars["tokenwise"].get()
         self.full_args.pre_ln = self.settings_vars["pre_ln"].get()
         self.full_args.n_layers = self.settings_vars["n_layers"].get()
@@ -1655,6 +1661,8 @@ class GUI(MainProcess):
                 self.run_full_finetuning()
             elif self.full_args.hybrid_probe:
                 self.run_hybrid_probes()
+            elif is_estimator_probe(self.full_args.probe_type):
+                self.run_estimator_probes()
             else:
                 self.run_nn_probes()
             print_done()

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -285,24 +285,24 @@ class HyperoptModule:
         params_to_hyperopt = sweep_config.get("parameters", {})
         
         # Filter parameters based on probe type and LoRA settings
-        probe_type = getattr(mp.probe_args, 'probe_type', 'linear')
+        probe_type = getattr(mp.probe_args, 'probe_type', 'mlp')
         use_lora = getattr(mp.probe_args, 'lora', False)
         
         # Define which parameters are relevant for each probe type
-        linear_probe_params = {'lr', 'weight_decay', 'hidden_size', 'n_layers', 'dropout', 'pre_ln', 'use_bias', 'probe_batch_size', 'embedding_hidden_state_index'}
+        mlp_probe_params = {'lr', 'weight_decay', 'hidden_size', 'n_layers', 'dropout', 'pre_ln', 'use_bias', 'probe_batch_size', 'embedding_hidden_state_index'}
         transformer_probe_params = {'lr', 'weight_decay', 'hidden_size', 'n_layers', 'transformer_dropout', 'pre_ln',
                                      'classifier_dropout', 'classifier_size', 'use_bias', 'probe_pooling_types', 'embedding_pooling_types', 'probe_batch_size',
                                      'embedding_hidden_state_index', 'bom_k', 'head_size', 'probe_grad_accum', 'add_token_ids', 'random_pair_flipping'}
         lora_params = {'lora_r', 'lora_alpha', 'lora_dropout'}
         
         # Determine which parameters to include
-        if probe_type == 'linear':
-            relevant_params = linear_probe_params
+        if probe_type == 'mlp':
+            relevant_params = mlp_probe_params
         elif probe_type == 'transformer':
             relevant_params = transformer_probe_params
         else:
             # For other probe types, include all common params
-            relevant_params = linear_probe_params | transformer_probe_params
+            relevant_params = mlp_probe_params | transformer_probe_params
         
         # Add LoRA parameters only if LoRA is enabled
         if use_lora:

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import sys
 
@@ -25,6 +26,7 @@ except ImportError:
             _spec.loader.exec_module(_protify_mod)
 
 from protify.cloud_cli import _run_on_cloud, _should_auto_run_cloud
+from protify.probes.estimator_probe import ESTIMATOR_PROBE_TYPES, check_task_type, is_estimator_probe
 
 
 def parse_arguments():  
@@ -82,9 +84,13 @@ def parse_arguments():
     parser.add_argument("--model_types", nargs="+", default=None, help="List of model type keywords paired with --model_paths (e.g. esm2, esmc, protbert, prott5, ankh, glm, dplm, dplm2, protclm, onehot, amplify, e1, calm, custom, random).")
     parser.add_argument("--model_dtype", type=str, choices=["fp32", "fp16", "bf16", "float32", "float16", "bfloat16"], default="bf16", help="Data type for loading base models.")
     parser.add_argument("--use_xformers", action="store_true", help="Use xformers memory-efficient attention for AMPLIFY models.")
+    parser.add_argument("--sae_layer", type=int, default=None, help="ESMC hidden-state layer the sparse autoencoder reads. Defaults to the 75%% depth layer each backbone publishes (23, 27, and 60). Only layers other than that one are restricted to --sae_k 64 with --sae_codebook_dim 16384.")
+    parser.add_argument("--sae_k", type=int, choices=[16, 32, 64, 128, 256, 512], default=None, help="Active sparse autoencoder features per residue. Defaults to 64.")
+    parser.add_argument("--sae_codebook_dim", type=int, choices=[8192, 16384, 32768, 65536, 131072], default=None, help="Sparse autoencoder codebook width, which is the embedding dimension per pooling type. Defaults to 8192.")
 
     # ----------------- ProbeArguments ----------------- #
-    parser.add_argument("--probe_type", choices=["linear", "transformer", "lyra"], default="linear", help="Type of probe.")
+    parser.add_argument("--probe_type", choices=["mlp", "linear", "transformer", "lyra", "xgboost", "lightgbm", "random_forest"], default="mlp", help="Type of probe. 'mlp' is the pooled feed-forward probe ('linear' is its former name and still works). 'xgboost', 'lightgbm', and 'random_forest' fit an estimator on pooled embeddings instead of a network.")
+    parser.add_argument("--probe_n_jobs", type=int, default=-1, help="Worker processes for estimator probes (xgboost, lightgbm, random_forest). -1 uses every core.")
     parser.add_argument("--tokenwise", action="store_true", help="Use a tokenwise probe (per-token outputs) instead of a sequence-level probe.")
     parser.add_argument("--hidden_size", type=int, default=8192, help="Hidden dimension size for probe.")
     parser.add_argument("--dropout", type=float, default=0.2, help="Dropout rate.")
@@ -277,7 +283,12 @@ def parse_arguments():
     if args.model_names is None and args.model_paths is None:
         args.model_names = ["ESM2-8"]
 
-    assert args.probe_type == "linear" or args.matrix_embed, "When probe_type is not linear, --matrix_embed must be True."
+    # Only probes that consume a pooled vector can run without per-residue embeddings.
+    pooled_vector_probes = ("mlp", "linear") + ESTIMATOR_PROBE_TYPES
+    assert args.probe_type in pooled_vector_probes or args.matrix_embed, (
+        f"--probe_type {args.probe_type} reads per-residue embeddings, so --matrix_embed must be set. "
+        f"Probes that take a pooled vector are {pooled_vector_probes}."
+    )
 
     if args.hf_token is not None:
         from huggingface_hub import login
@@ -472,6 +483,11 @@ def parse_arguments():
             yaml_args.model_types = args.model_types
         if "model_names" not in yaml_args.__dict__:
             yaml_args.model_names = args.model_names
+        # A YAML file names the settings a run cares about, not every argument. Backfill
+        # the rest from the parser so adding an argument does not break existing configs.
+        for key, value in args.__dict__.items():
+            if key not in yaml_args.__dict__:
+                setattr(yaml_args, key, value)
         return yaml_args
     else:
         return args
@@ -529,6 +545,7 @@ from protify.data.data_mixin import DataArguments, DataMixin
 from protify.embedder import Embedder, EmbeddingArguments, get_embedding_filename
 from protify.hyperopt_utils import HyperoptModule
 from protify.logger import MetricsLogger, log_method_calls
+from protify.probes.estimator_probe import EstimatorProbeArguments, train_estimator_probe
 from protify.probes.get_probe import ProbeArguments, get_probe
 from protify.probes.scikit_classes import ScikitArguments, ScikitProbe
 from protify.probes.trainers import TrainerArguments, TrainerMixin
@@ -1036,14 +1053,79 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                 torch.cuda.empty_cache()
 
     @log_method_calls
-    def run_scikit_scheme(self):    
+    def run_estimator_probes(self):
+        """Fit gradient-boosted or forest probes on pooled embeddings.
+
+        Shares the embedding cache, results table, and plots with the neural probes, so
+        --probe_type xgboost differs from --probe_type mlp only in the learner.
+        """
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        for display_name, dispatch_type, model_path in self.model_args.model_entries():
+            for data_name, dataset in self.datasets.items():
+                num_labels = dataset[3]
+                X_train, y_train, X_valid, y_valid, X_test, y_test, label_type = self.prepare_scikit_dataset(
+                    display_name,
+                    dataset,
+                    standardize=False,
+                    flip_train_pairs=self.full_args.random_pair_flipping,
+                )
+                check_task_type(self.probe_args.probe_type, label_type)
+                if label_type == 'multilabel':
+                    # prepare_scikit_dataset flattens list-valued labels; estimators need
+                    # one row of targets per sample.
+                    y_train = y_train.reshape(-1, num_labels)
+                    y_valid = y_valid.reshape(-1, num_labels)
+                    y_test = y_test.reshape(-1, num_labels)
+                self.logger.info(f'Training {self.probe_args.probe_type} probe for {data_name} with {display_name}')
+
+                valid_runs, test_runs = [], []
+                for run_index in range(self.trainer_args.num_runs):
+                    estimator_args = EstimatorProbeArguments(
+                        probe_type=self.probe_args.probe_type,
+                        task_type=label_type,
+                        num_labels=num_labels,
+                        seed=self.full_args.seed + run_index,
+                        n_jobs=self.full_args.probe_n_jobs,
+                        device=device,
+                        overrides=self._estimator_overrides(),
+                    )
+                    _, valid_metrics, test_metrics = train_estimator_probe(
+                        estimator_args, X_train, y_train, X_valid, y_valid, X_test, y_test,
+                    )
+                    valid_runs.append(valid_metrics)
+                    test_runs.append(test_metrics)
+
+                # A single run reports raw metrics; several report mean and standard
+                # deviation, matching how the neural probes report multi-run results.
+                if len(valid_runs) == 1:
+                    valid_metrics, test_metrics = valid_runs[0], test_runs[0]
+                else:
+                    valid_metrics = self._aggregate_metrics(valid_runs)
+                    test_metrics = self._aggregate_metrics(test_runs)
+                self.log_metrics(data_name, display_name, valid_metrics, split_name='valid')
+                self.log_metrics(data_name, display_name, test_metrics, split_name='test')
+
+    def _estimator_overrides(self):
+        """Estimator hyperparameters supplied through --scikit_model_args JSON."""
+        raw = getattr(self.full_args, 'scikit_model_args', None)
+        if not raw:
+            return {}
+
+        overrides = json.loads(raw)
+        print_message(f'Overriding {self.probe_args.probe_type} hyperparameters: {overrides}')
+        return overrides
+
+    @log_method_calls
+    def run_scikit_scheme(self):
         self.scikit_args = self._build_scikit_args()
         scikit_probe = ScikitProbe(self.scikit_args)
         for display_name, dispatch_type, model_path in self.model_args.model_entries():
             for data_name, dataset in self.datasets.items():
                 ### find best scikit model and parameters via cross validation and lazy predict
-                X_train, y_train, X_valid, y_valid, X_test, y_test, label_type = self.prepare_scikit_dataset(display_name, dataset)
-                
+                X_train, y_train, X_valid, y_valid, X_test, y_test, label_type = self.prepare_scikit_dataset(
+                    display_name, dataset, flip_train_pairs=self.full_args.random_pair_flipping
+                )
+
                 # If a specific model is specified, skip LazyPredict and go straight to that model
                 if self.scikit_args.model_name is not None:
                     print_message(f"Skipping LazyPredict, using specified model: {self.scikit_args.model_name}")
@@ -1217,7 +1299,10 @@ def main(args: SimpleNamespace):
               if os.environ.get('_PROTIFY_EMBED_PHASE') == '1':
                   print_message("Embed phase complete, proceeding to merge and train.")
                   return
-              main.run_nn_probes()
+              if is_estimator_probe(main.full_args.probe_type):
+                  main.run_estimator_probes()
+              else:
+                  main.run_nn_probes()
         else:
             # Determine if current experiment passed datasets
             has_datasets = bool(getattr(args, 'data_names', []) or getattr(args, 'data_dirs', []))
@@ -1245,7 +1330,10 @@ def main(args: SimpleNamespace):
                     if os.environ.get('_PROTIFY_EMBED_PHASE') == '1':
                         print_message("Embed phase complete, proceeding to merge and train.")
                         return
-                    main.run_nn_probes()
+                    if is_estimator_probe(main.full_args.probe_type):
+                        main.run_estimator_probes()
+                    else:
+                        main.run_nn_probes()
             else:
                 print_message("No datasets specified; proceeding with ProteinGym.")
 

--- a/src/protify/pooler.py
+++ b/src/protify/pooler.py
@@ -22,6 +22,19 @@ class Pooler:
             'cls': self.cls_pooling,
             'parti': self._pool_parti,
         }
+        # Reject bad names here rather than at the first forward pass, where the run has
+        # already paid for a model load and an embedding pass.
+        unknown = [name for name in pooling_types if name not in self.pooling_options]
+        if unknown:
+            raise ValueError(
+                f"Unknown pooling types {unknown}; expected any of {sorted(self.pooling_options)}."
+            )
+        duplicates = [name for name in set(pooling_types) if pooling_types.count(name) > 1]
+        if duplicates:
+            raise ValueError(
+                f"Pooling types {duplicates} appear more than once. Each one widens the "
+                f"embedding by the hidden size, so repeats only waste space."
+            )
 
     def _create_pooled_matrices_across_layers(self, attentions: torch.Tensor) -> torch.Tensor:
         # attentions: (b, r, l, l); r = attention matrices or layers
@@ -162,8 +175,10 @@ class Pooler:
         **kwargs: object,
     ) -> torch.Tensor:
         # emb: (b, l, d); attention_mask: (b, l)
+        # Population standard deviation in both branches. The masked path divides by the
+        # residue count, so an unbiased estimate here would not agree with it.
         if attention_mask is None:
-            return emb.std(dim=1)  # (b, d)
+            return emb.std(dim=1, unbiased=False)  # (b, d)
 
         var = self.var_pooling(emb, attention_mask, **kwargs)  # (b, d)
         return torch.sqrt(var)  # (b, d)

--- a/src/protify/pooler.py
+++ b/src/protify/pooler.py
@@ -190,8 +190,11 @@ class Pooler:
         **kwargs: object,
     ) -> torch.Tensor:
         # emb: (b, l, d); attention_mask: (b, l)
+        # Population variance in both branches, matching std_pooling. The masked path
+        # divides by the residue count, so an unbiased estimate here would disagree with
+        # it, and with std ** 2, for the same sequence.
         if attention_mask is None:
-            return emb.var(dim=1)  # (b, d)
+            return emb.var(dim=1, unbiased=False)  # (b, d)
 
         attention_mask = attention_mask.unsqueeze(-1)  # (b, l, 1)
         mean = (emb * attention_mask).sum(dim=1) / attention_mask.sum(dim=1)  # (b, d)

--- a/src/protify/probes/__init__.py
+++ b/src/protify/probes/__init__.py
@@ -1,6 +1,6 @@
 """Public probe classes and parallel-probe planning helpers."""
 
-from .linear_probe import LinearProbe, LinearProbeConfig
+from .mlp_probe import MLPProbe, MLPProbeConfig
 from .parallel_probe_batches import ParallelRunDataset
 from .parallel_linear_probe import (
     ParallelLinearProbe,
@@ -36,8 +36,8 @@ from .transformer_probe import (
 from .packaged_probe_model import PackagedProbeConfig, PackagedProbeModel
 
 __all__ = [
-    "LinearProbe",
-    "LinearProbeConfig",
+    "MLPProbe",
+    "MLPProbeConfig",
     "ParallelRunDataset",
     "ParallelLinearProbe",
     "ParallelLinearProbeConfig",

--- a/src/protify/probes/estimator_probe.py
+++ b/src/protify/probes/estimator_probe.py
@@ -173,22 +173,56 @@ def _fit(
     return estimator
 
 
+# Keeps the log transforms below finite when an estimator returns a saturated probability.
+_PROBABILITY_EPSILON = 1e-7
+
+
+def _positive_probability(block: np.ndarray, classes: np.ndarray) -> np.ndarray:
+    """P(label = 1) from one label's predict_proba block.
+
+    `num_labels` counts the labels present across train, valid, and test, so a label the
+    training split never varies still gets a column here. Its fitted estimator saw one
+    class and can only ever predict that class, whatever width its block comes back at:
+    scikit-learn returns (n, 1) there while XGBoost and LightGBM still return (n, 2).
+    """
+    # block: (n, u); classes: (u',) values this label took in the training split
+    if classes.size == 1:
+        return np.full(block.shape[0], float(classes[0] == 1))  # (n,)
+
+    return block[:, np.flatnonzero(classes == 1)[0]].astype(np.float64)  # (n,)
+
+
 def _predictions(estimator: Any, X: np.ndarray, task_type: str) -> np.ndarray:
-    """Scores in the layout the shared metric functions expect."""
+    """Scores in the layout the shared metric functions expect.
+
+    Those functions were written for neural probes, so they read their input as raw logits:
+    the single-label one softmaxes before computing AUC, and the multi-label one sigmoids
+    before thresholding at 0.5. Passing probabilities straight through would squash them a
+    second time, which pushes every non-zero multi-label score above the threshold. Log
+    probabilities and log odds invert each squash exactly, since softmax(log p) = p once the
+    row sums to one, and sigmoid(log(p / (1 - p))) = p.
+    """
     # X: (n, d)
     if task_type in REGRESSION_TASK_TYPES:
         return estimator.predict(X)  # (n,)
 
     if task_type == "multilabel":
-        # MultiOutputClassifier yields one (n, 2) array per label.
+        # One block per label, and one class vector per label alongside it. MultiOutputClassifier
+        # and a natively multi-output RandomForestClassifier both lay `classes_` out that way.
         per_label = estimator.predict_proba(X)
-        return np.stack([column[:, 1] for column in per_label], axis=1)  # (n, c)
+        probabilities = np.stack(
+            [_positive_probability(block, classes)
+             for block, classes in zip(per_label, estimator.classes_)],
+            axis=1,
+        )  # (n, c)
+        probabilities = np.clip(probabilities, _PROBABILITY_EPSILON, 1.0 - _PROBABILITY_EPSILON)
+        return np.log(probabilities / (1.0 - probabilities))  # (n, c)
 
     probabilities = estimator.predict_proba(X)  # (n, c)
     if probabilities.shape[1] == 1:
         probabilities = np.concatenate([1.0 - probabilities, probabilities], axis=1)  # (n, 2)
 
-    return probabilities  # (n, c)
+    return np.log(np.clip(probabilities, _PROBABILITY_EPSILON, None))  # (n, c)
 
 
 def _metric_function(task_type: str) -> Callable[[Any], dict[str, float]]:

--- a/src/protify/probes/estimator_probe.py
+++ b/src/protify/probes/estimator_probe.py
@@ -1,0 +1,250 @@
+"""Gradient-boosted and forest probes over pooled embeddings.
+
+These probes sit beside the neural probes in `--probe_type` rather than behind the
+separate `--use_scikit` branch, so they share the embedding cache, results table, plots,
+and multi-run seed handling.
+
+Axis-aligned learners suit sparse autoencoder features in particular. A max-pooled SAE
+vector answers "did this protein ever express feature j, and how strongly", which is the
+question a decision-tree split asks directly. Dense PLM embeddings work too, but the
+defaults here are chosen for the wide, non-negative, mostly zero SAE case.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+# Metrics, transformers, and the estimator libraries load inside the functions that need
+# them. `main.parse_arguments` reads ESTIMATOR_PROBE_TYPES before `entrypoint_setup` has
+# configured the torch and TensorFlow environment, so importing them here would run those
+# frameworks too early.
+
+
+ESTIMATOR_PROBE_TYPES = ("xgboost", "lightgbm", "random_forest")
+
+# Defaults for wide, sparse, non-negative features such as max-pooled SAE codebooks.
+#
+# The xgboost values were selected on validation MCC over seeds 42 to 44, fitting
+# ESMC-300-SAE-l23-k64-c8192 max-pooled features on the solubility dataset (55536 train
+# rows, 8192 features). They reach 0.4864 validation MCC against 0.4458 for XGBoost's own
+# library defaults, a gap around ten times the 0.0044 seed standard deviation. That
+# selection predates the move to the FastPLMs SAE runtime, whose residue standardization
+# raised the same features from 23.7% to 36.6% non-zero; the defaults were not reselected
+# afterwards. Most of the gap comes from many shallow-learning-rate trees under early
+# stopping rather than from any single setting: sweeping `colsample_bytree` from 0.1 to
+# 1.0 moved validation MCC by less than 0.01 and barely moved fit time. It stays low
+# because the cost of scanning every column grows with codebook width, not because it
+# was measured to help accuracy.
+#
+# The lightgbm and random_forest values mirror the same shape and are not separately
+# measured. Override any of them with --scikit_model_args.
+ESTIMATOR_DEFAULTS: dict[str, dict[str, Any]] = {
+    "xgboost": {
+        "n_estimators": 1000,
+        "learning_rate": 0.02,
+        "max_depth": 8,
+        "min_child_weight": 16,
+        "subsample": 1.0,
+        "colsample_bytree": 0.3,
+        "reg_lambda": 1.0,
+        "tree_method": "hist",
+        "early_stopping_rounds": 50,
+    },
+    "lightgbm": {
+        "n_estimators": 1000,
+        "learning_rate": 0.02,
+        "num_leaves": 127,
+        "min_child_samples": 16,
+        "colsample_bytree": 0.3,
+        "reg_lambda": 1.0,
+        "verbosity": -1,
+    },
+    "random_forest": {
+        "n_estimators": 500,
+        "max_features": "sqrt",
+        "min_samples_leaf": 1,
+    },
+}
+
+
+@dataclass
+class EstimatorProbeArguments:
+    """Configuration for one estimator probe fit."""
+
+    probe_type: str
+    task_type: str
+    num_labels: int = 2
+    seed: int = 42
+    n_jobs: int = -1
+    device: str = "cpu"
+    overrides: dict[str, Any] = field(default_factory=dict)
+
+
+# Task types an estimator probe can fit. Token-level tasks are excluded because these
+# learners consume one pooled vector per sequence, not a per-residue sequence.
+REGRESSION_TASK_TYPES = ("regression", "sigmoid_regression")
+SUPPORTED_TASK_TYPES = REGRESSION_TASK_TYPES + ("singlelabel", "multilabel")
+
+
+def is_estimator_probe(probe_type: str) -> bool:
+    return probe_type in ESTIMATOR_PROBE_TYPES
+
+
+def check_task_type(probe_type: str, task_type: str) -> None:
+    if task_type not in SUPPORTED_TASK_TYPES:
+        raise ValueError(
+            f"--probe_type {probe_type} fits one pooled vector per sequence and cannot "
+            f"handle task type {task_type!r}. Supported types are {SUPPORTED_TASK_TYPES}."
+        )
+
+
+def _load_estimator_classes(probe_type: str) -> tuple[type, type]:
+    """Return the (classifier, regressor) pair for a probe type."""
+    if probe_type == "xgboost":
+        from xgboost import XGBClassifier, XGBRegressor
+
+        return XGBClassifier, XGBRegressor
+    if probe_type == "lightgbm":
+        from lightgbm import LGBMClassifier, LGBMRegressor
+
+        return LGBMClassifier, LGBMRegressor
+    if probe_type == "random_forest":
+        from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+
+        return RandomForestClassifier, RandomForestRegressor
+
+    raise ValueError(f"{probe_type!r} is not an estimator probe; expected {ESTIMATOR_PROBE_TYPES}.")
+
+
+def build_estimator(args: EstimatorProbeArguments) -> Any:
+    """Construct an unfitted estimator with the tuned defaults and any overrides."""
+    check_task_type(args.probe_type, args.task_type)
+    classifier_cls, regressor_cls = _load_estimator_classes(args.probe_type)
+    params = dict(ESTIMATOR_DEFAULTS[args.probe_type])
+    params["random_state"] = args.seed
+
+    if args.probe_type in ("lightgbm", "random_forest"):
+        params["n_jobs"] = args.n_jobs
+    if args.probe_type == "xgboost":
+        params["n_jobs"] = args.n_jobs
+        params["device"] = args.device
+        if args.task_type == "singlelabel":
+            params["objective"] = (
+                "binary:logistic" if args.num_labels <= 2 else "multi:softprob"
+            )
+
+    if args.task_type == "multilabel" and args.probe_type != "random_forest":
+        # XGBoost and LightGBM need an explicit wrapper for multi-output targets, and
+        # early stopping needs a per-output eval set the wrapper cannot supply.
+        from sklearn.multioutput import MultiOutputClassifier
+
+        params.pop("early_stopping_rounds", None)
+        params.update(args.overrides)
+        return MultiOutputClassifier(classifier_cls(**params), n_jobs=1)
+
+    # Overrides land last so every default, including the objective, stays adjustable.
+    params.update(args.overrides)
+
+    if args.task_type in REGRESSION_TASK_TYPES:
+        return regressor_cls(**params)
+
+    return classifier_cls(**params)
+
+
+def _fit(
+    estimator: Any,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_valid: np.ndarray,
+    y_valid: np.ndarray,
+) -> Any:
+    """Fit an estimator, passing a validation set when it supports early stopping."""
+    # X_train: (n_train, d); y_train: (n_train,) or (n_train, c)
+    uses_early_stopping = getattr(estimator, "early_stopping_rounds", None) is not None
+    if uses_early_stopping:
+        estimator.fit(X_train, y_train, eval_set=[(X_valid, y_valid)], verbose=False)
+    else:
+        estimator.fit(X_train, y_train)
+
+    return estimator
+
+
+def _predictions(estimator: Any, X: np.ndarray, task_type: str) -> np.ndarray:
+    """Scores in the layout the shared metric functions expect."""
+    # X: (n, d)
+    if task_type in REGRESSION_TASK_TYPES:
+        return estimator.predict(X)  # (n,)
+
+    if task_type == "multilabel":
+        # MultiOutputClassifier yields one (n, 2) array per label.
+        per_label = estimator.predict_proba(X)
+        return np.stack([column[:, 1] for column in per_label], axis=1)  # (n, c)
+
+    probabilities = estimator.predict_proba(X)  # (n, c)
+    if probabilities.shape[1] == 1:
+        probabilities = np.concatenate([1.0 - probabilities, probabilities], axis=1)  # (n, 2)
+
+    return probabilities  # (n, c)
+
+
+def _metric_function(task_type: str) -> Callable[[Any], dict[str, float]]:
+    try:
+        from metrics import (
+            compute_multi_label_classification_metrics,
+            compute_regression_metrics,
+            compute_single_label_classification_metrics,
+        )
+    except ImportError:
+        from ..metrics import (
+            compute_multi_label_classification_metrics,
+            compute_regression_metrics,
+            compute_single_label_classification_metrics,
+        )
+
+    if task_type in REGRESSION_TASK_TYPES:
+        return compute_regression_metrics
+    if task_type == "multilabel":
+        return compute_multi_label_classification_metrics
+
+    return compute_single_label_classification_metrics
+
+
+def train_estimator_probe(
+    args: EstimatorProbeArguments,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_valid: np.ndarray,
+    y_valid: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+) -> tuple[Any, dict[str, float], dict[str, float]]:
+    """Fit one estimator probe and score it on the validation and test splits."""
+    # X_*: (n_split, d); y_*: (n_split,) or (n_split, c)
+    from transformers import EvalPrediction
+
+    try:
+        from utils import print_message
+    except ImportError:
+        from ..utils import print_message
+
+    estimator = build_estimator(args)
+    print_message(
+        f"Fitting {args.probe_type} probe on {X_train.shape[0]} samples "
+        f"with {X_train.shape[1]} features "
+        f"({100 * float(np.count_nonzero(X_train)) / X_train.size:.1f}% non-zero)"
+    )
+    estimator = _fit(estimator, X_train, y_train, X_valid, y_valid)
+
+    compute_metrics = _metric_function(args.task_type)
+    valid_metrics = compute_metrics(
+        EvalPrediction(predictions=_predictions(estimator, X_valid, args.task_type), label_ids=y_valid)
+    )
+    test_metrics = compute_metrics(
+        EvalPrediction(predictions=_predictions(estimator, X_test, args.task_type), label_ids=y_test)
+    )
+
+    return estimator, valid_metrics, test_metrics

--- a/src/protify/probes/export_packaged_model.py
+++ b/src/protify/probes/export_packaged_model.py
@@ -21,8 +21,8 @@ except ImportError:
 
 def _infer_probe_type(probe_model: nn.Module) -> str:
     probe_class_name = probe_model.__class__.__name__
-    if probe_class_name == "LinearProbe":
-        return "linear"
+    if probe_class_name == "MLPProbe":
+        return "mlp"
     if probe_class_name in ["TransformerForSequenceClassification", "TransformerForTokenClassification"]:
         return "transformer"
     if probe_class_name in ["LyraForSequenceClassification", "LyraForTokenClassification"]:

--- a/src/protify/probes/get_probe.py
+++ b/src/protify/probes/get_probe.py
@@ -2,9 +2,19 @@ import importlib
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from .linear_probe import LinearProbe, LinearProbeConfig
+from .mlp_probe import MLPProbe, MLPProbeConfig
 from .transformer_probe import TransformerForSequenceClassification, TransformerForTokenClassification, TransformerProbeConfig
 from .lyra_probe import LyraForSequenceClassification, LyraForTokenClassification, LyraConfig
+
+
+# The feed-forward probe was called a linear probe before it grew hidden layers. Saved
+# probe configs, published repositories, and existing YAML all carry the old value, so it
+# resolves to the current name rather than failing.
+_RENAMED_PROBE_TYPES = {'linear': 'mlp'}
+
+
+def normalize_probe_type(probe_type: str) -> str:
+    return _RENAMED_PROBE_TYPES.get(probe_type, probe_type)
 
 
 # External probe types can be registered here by packages on PYTHONPATH.
@@ -37,9 +47,9 @@ def _load_external_probe(probe_type: str, tokenwise: bool, config_kwargs: dict):
 class ProbeArguments:
     def __init__(
             self,
-            probe_type: str = 'linear', # valid options: linear, transformer, lyra
+            probe_type: str = 'mlp', # valid options: mlp, transformer, lyra, xgboost, lightgbm, random_forest
             tokenwise: bool = False,
-            ### Linear Probe
+            ### MLP Probe
             input_size: int = 960,
             hidden_size: int = 8192,
             dropout: float = 0.2,
@@ -70,7 +80,7 @@ class ProbeArguments:
             **kwargs,
 
     ):
-        self.probe_type = probe_type
+        self.probe_type = normalize_probe_type(probe_type)
         self.tokenwise = tokenwise
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -109,9 +119,9 @@ def get_probe(args: ProbeArguments):
             f"(probe_type='transformer', tokenwise=False). Got probe_type={args.probe_type!r}, "
             f"tokenwise={args.tokenwise}."
         )
-    if args.probe_type == 'linear' and not args.tokenwise:
-        config = LinearProbeConfig(**args.__dict__)
-        return LinearProbe(config)
+    if args.probe_type == 'mlp' and not args.tokenwise:
+        config = MLPProbeConfig(**args.__dict__)
+        return MLPProbe(config)
     elif args.probe_type == 'transformer' and not args.tokenwise:
         config = TransformerProbeConfig(**args.__dict__)
         return TransformerForSequenceClassification(config)
@@ -142,9 +152,11 @@ def rebuild_probe_from_saved_config(
     if "pooling_types" in config_dict and "probe_pooling_types" not in config_dict:
         config_dict["probe_pooling_types"] = config_dict["pooling_types"]
 
-    if probe_type == "linear" and not tokenwise:
-        config = LinearProbeConfig(**config_dict)
-        return LinearProbe(config)
+    probe_type = normalize_probe_type(probe_type)
+
+    if probe_type == "mlp" and not tokenwise:
+        config = MLPProbeConfig(**config_dict)
+        return MLPProbe(config)
     if probe_type == "transformer" and not tokenwise:
         config = TransformerProbeConfig(**config_dict)
         return TransformerForSequenceClassification(config)

--- a/src/protify/probes/mlp_probe.py
+++ b/src/protify/probes/mlp_probe.py
@@ -15,7 +15,9 @@ except ImportError:
 from .losses import get_loss_fct
 
 
-class LinearProbeConfig(PretrainedConfig):
+class MLPProbeConfig(PretrainedConfig):
+    # Serialized identifier from when this probe was called a linear probe. Published
+    # probe repositories carry it in their config.json, so it stays as written.
     model_type = "linear_probe"
 
     def __init__(
@@ -41,11 +43,17 @@ class LinearProbeConfig(PretrainedConfig):
         self.use_bias = use_bias
 
 
-class LinearProbe(PreTrainedModel):
-    config_class = LinearProbeConfig
+class MLPProbe(PreTrainedModel):
+    """Feed-forward probe over a pooled embedding.
+
+    Named for what it is: a stack of Linear, ReLU, and Dropout layers, not a single
+    linear map. `--probe_type linear` still selects it.
+    """
+
+    config_class = MLPProbeConfig
     all_tied_weights_keys = {}
 
-    def __init__(self, config: LinearProbeConfig) -> None:
+    def __init__(self, config: MLPProbeConfig) -> None:
         super().__init__(config)
         self.config = config
         self.task_type = config.task_type

--- a/src/protify/probes/packaged_probe_model.py
+++ b/src/protify/probes/packaged_probe_model.py
@@ -16,7 +16,7 @@ class PackagedProbeConfig(PretrainedConfig):
     def __init__(
         self,
         base_model_name: str = "",
-        probe_type: str = "linear",
+        probe_type: str = "mlp",
         probe_config: dict[str, Any] | None = None,
         tokenwise: bool = False,
         matrix_embed: bool = False,
@@ -219,7 +219,8 @@ class PackagedProbeModel(PreTrainedModel):
             attentions=attentions,
         )  # (b, d_probe) or (b, l, d); mask is (b, l) or None
 
-        if self.config.probe_type == "linear":
+        # Exported repositories predating the rename still carry "linear".
+        if self.config.probe_type in ("mlp", "linear"):
             probe_output = self.probe(embeddings=probe_embeddings, labels=labels)
             return probe_output  # logits: (b, c)
 

--- a/src/protify/probes/parallel_linear_probe.py
+++ b/src/protify/probes/parallel_linear_probe.py
@@ -7,9 +7,9 @@ from transformers import PreTrainedModel, PretrainedConfig
 from transformers.modeling_outputs import SequenceClassifierOutput
 
 try:
-    from .linear_probe import LinearProbe, LinearProbeConfig
+    from .mlp_probe import MLPProbe, MLPProbeConfig
 except ImportError:
-    from probes.linear_probe import LinearProbe, LinearProbeConfig
+    from probes.mlp_probe import MLPProbe, MLPProbeConfig
 try:
     from ..model_components.mlp import intermediate_correction_fn
 except ImportError:
@@ -194,7 +194,7 @@ class ParallelLinearProbe(PreTrainedModel):
         ]
 
     def _reset_from_linear_probes(self, seeds: list[int]) -> None:
-        single_config = LinearProbeConfig(
+        single_config = MLPProbeConfig(
             input_size=self.config.input_size,
             hidden_size=self.config.hidden_size,
             dropout=self.config.dropout,
@@ -209,7 +209,7 @@ class ParallelLinearProbe(PreTrainedModel):
             for run_idx, seed in enumerate(seeds):
                 with torch.random.fork_rng(devices=[]):
                     torch.manual_seed(seed)
-                    probe = LinearProbe(single_config)
+                    probe = MLPProbe(single_config)
                 single_param_layers = [
                     layer for layer in probe.layers
                     if isinstance(layer, (nn.Linear, nn.LayerNorm))
@@ -411,9 +411,9 @@ class ParallelLinearProbe(PreTrainedModel):
             attentions=None,
         )
 
-    def to_linear_probe(self, run_idx: int) -> LinearProbe:
+    def to_mlp_probe(self, run_idx: int) -> MLPProbe:
         assert 0 <= run_idx < self.num_runs, f"run_idx must be in [0, {self.num_runs})"
-        config = LinearProbeConfig(
+        config = MLPProbeConfig(
             input_size=self.config.input_size,
             hidden_size=self.config.hidden_size,
             dropout=self.config.dropout,
@@ -423,7 +423,7 @@ class ParallelLinearProbe(PreTrainedModel):
             pre_ln=self.config.pre_ln,
             use_bias=self.config.use_bias,
         )
-        probe = LinearProbe(config)
+        probe = MLPProbe(config)
         parallel_param_layers = self._parameter_layers()
         single_param_layers = [
             layer for layer in probe.layers

--- a/src/protify/probes/parallel_probe_plan.py
+++ b/src/protify/probes/parallel_probe_plan.py
@@ -8,6 +8,7 @@ except ImportError:
         from protify.model_components.mlp import intermediate_correction_fn
     except ImportError:
         from model_components.mlp import intermediate_correction_fn
+from .get_probe import normalize_probe_type
 
 
 ParallelProbeCompatibilityKey = Tuple[object, ...]
@@ -40,9 +41,14 @@ class ParallelProbeRunSpec:
     full_finetuning: bool = False
     save_model: bool = False
 
+    def __post_init__(self) -> None:
+        # Specs arrive from probe arguments, planning scripts, and saved manifests, so
+        # the former probe name is resolved here rather than at every comparison.
+        object.__setattr__(self, 'probe_type', normalize_probe_type(self.probe_type))
+
     def is_parallel_linear_eligible(self) -> bool:
         return (
-            self.probe_type == 'linear'
+            self.probe_type == 'mlp'
             and not self.tokenwise
             and not self.matrix_embed
             and not self.full_finetuning
@@ -50,7 +56,7 @@ class ParallelProbeRunSpec:
 
     def ineligibility_reasons(self) -> Tuple[str, ...]:
         reasons = []
-        if self.probe_type != 'linear':
+        if self.probe_type != 'mlp':
             reasons.append('probe_type')
         if self.tokenwise:
             reasons.append('tokenwise')
@@ -474,7 +480,7 @@ def linear_probe_parameter_count(
 
 
 def linear_probe_parameter_count_for_spec(spec: ParallelProbeRunSpec) -> int:
-    assert spec.probe_type == 'linear', "Only linear probe specs have known parameter counts."
+    assert spec.probe_type == 'mlp', "Only MLP probe specs have known parameter counts."
     return linear_probe_parameter_count(
         input_size=spec.input_size,
         hidden_size=spec.hidden_size,
@@ -536,7 +542,7 @@ def estimate_parallel_probe_group(
     assert dataset_size >= 0, "dataset_size must be non-negative."
     assert index_dtype_bytes > 0, "index_dtype_bytes must be positive."
 
-    parameter_count_known = group.runs[0].probe_type == 'linear'
+    parameter_count_known = group.runs[0].probe_type == 'mlp'
     if parameter_count_known:
         single_probe_parameter_count = linear_probe_parameter_count_for_spec(group.runs[0])
         batch_activation_count = linear_probe_batch_activation_count(

--- a/src/protify/probes/trainers.py
+++ b/src/protify/probes/trainers.py
@@ -752,7 +752,7 @@ Protify is an open source platform designed to simplify and democratize workflow
         return (
             self.trainer_args.parallel_probe_runs
             and self.trainer_args.num_runs > 1
-            and self.probe_args.probe_type == 'linear'
+            and self.probe_args.probe_type == 'mlp'
             and not self.probe_args.tokenwise
             and not self.embedding_args.matrix_embed
             and not ppi
@@ -961,7 +961,7 @@ Protify is an open source platform designed to simplify and democratize workflow
                 )
                 print_message(
                     f"Raw best parallel probe uploaded to Hugging Face Hub: {repo_id} "
-                    f"(load with e.g. LinearProbe.from_pretrained('{repo_id}'))"
+                    f"(load with e.g. MLPProbe.from_pretrained('{repo_id}'))"
                 )
             else:
                 packaged_export_succeeded = False
@@ -1234,7 +1234,7 @@ Protify is an open source platform designed to simplify and democratize workflow
                         best_run_idx = global_run_idx
                         best_run_id = run_spec.run_id
                         best_seed = run_spec.seed
-                        best_model = parallel_model.to_linear_probe(local_run_idx)
+                        best_model = parallel_model.to_mlp_probe(local_run_idx)
                         best_y_pred = test_logits[:, local_run_idx, :].astype(np.float32)
                         best_y_true = test_labels.astype(np.float32)
 

--- a/src/protify/resource_info.py
+++ b/src/protify/resource_info.py
@@ -67,6 +67,24 @@ model_descriptions = {
         'type': 'Protein language model',
         'citation': 'N/A'
     },
+    'ESMC-300-SAE': {
+        'description': 'ESMC 300M read through a Biohub sparse autoencoder, giving sparse codebook features per residue. Defaults to layer 23, k 64, codebook 8192.',
+        'size': '300M parameters plus the sparse autoencoder codebook',
+        'type': 'Protein language model sparse autoencoder',
+        'citation': 'biohub/ESMC-SAE-Overview'
+    },
+    'ESMC-600-SAE': {
+        'description': 'ESMC 600M read through a Biohub sparse autoencoder. Defaults to layer 27, k 64, codebook 8192.',
+        'size': '600M parameters plus the sparse autoencoder codebook',
+        'type': 'Protein language model sparse autoencoder',
+        'citation': 'biohub/ESMC-SAE-Overview'
+    },
+    'ESMC-6B-SAE': {
+        'description': 'ESMC 6B read through a Biohub sparse autoencoder. Defaults to layer 60, k 64, codebook 8192.',
+        'size': '6.352B parameters plus the sparse autoencoder codebook',
+        'type': 'Protein language model sparse autoencoder',
+        'citation': 'biohub/ESMC-SAE-Overview'
+    },
     'ProtBert': {
         'description': 'BERT-based protein language model trained on protein sequences from UniRef.',
         'size': '420M parameters',

--- a/src/protify/scripts/benchmark_parallel_probes.py
+++ b/src/protify/scripts/benchmark_parallel_probes.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from torch.utils.data import DataLoader, TensorDataset
 
 try:
-    from probes.linear_probe import LinearProbe, LinearProbeConfig
+    from probes.mlp_probe import MLPProbe, MLPProbeConfig
     from probes.parallel_linear_probe import ParallelLinearProbe, ParallelLinearProbeConfig
     from probes.parallel_probe_batches import ParallelRunDataset
     from probes.parallel_probe_plan import (
@@ -16,7 +16,7 @@ try:
         plan_parallel_probe_runs,
     )
 except ImportError:
-    from protify.probes.linear_probe import LinearProbe, LinearProbeConfig
+    from protify.probes.mlp_probe import MLPProbe, MLPProbeConfig
     from protify.probes.parallel_linear_probe import ParallelLinearProbe, ParallelLinearProbeConfig
     from protify.probes.parallel_probe_batches import ParallelRunDataset
     from protify.probes.parallel_probe_plan import (
@@ -139,7 +139,7 @@ def build_synthetic_plan(args: argparse.Namespace) -> ParallelProbeExecutionPlan
         embedding_key=f"synthetic:{args.num_samples}:{args.input_size}:{args.task_type}",
         dataset_key=f"synthetic:{args.num_samples}:{args.num_labels}",
         trainer_key=parallel_probe_trainer_key(args),
-        probe_type="linear",
+        probe_type="mlp",
         input_size=args.input_size,
         hidden_size=args.hidden_size,
         dropout=args.dropout,
@@ -324,7 +324,7 @@ def train_sequential(
         run_seed = args.seed + run_idx
         with torch.random.fork_rng(devices=[]):
             torch.manual_seed(run_seed)
-            config = LinearProbeConfig(
+            config = MLPProbeConfig(
                 input_size=args.input_size,
                 hidden_size=args.hidden_size,
                 dropout=args.dropout,
@@ -334,7 +334,7 @@ def train_sequential(
                 pre_ln=True,
                 use_bias=True,
             )
-            model = LinearProbe(config).to(device)
+            model = MLPProbe(config).to(device)
         optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
         loader = make_loader(dataset, args.batch_size, run_seed)
         model.train()

--- a/src/protify/scripts/plan_parallel_probes.py
+++ b/src/protify/scripts/plan_parallel_probes.py
@@ -23,6 +23,7 @@ try:
         plan_parallel_probe_runs,
         schedule_parallel_probe_execution_waves,
     )
+    from probes.get_probe import normalize_probe_type
 except ImportError:
     from protify.probes.parallel_probe_plan import (
         ParallelProbeCompatibilityKey,
@@ -43,6 +44,7 @@ except ImportError:
         plan_parallel_probe_runs,
         schedule_parallel_probe_execution_waves,
     )
+    from protify.probes.get_probe import normalize_probe_type
 
 
 GroupSizeCaps = dict[ParallelProbeCompatibilityKey, int]
@@ -78,7 +80,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=["singlelabel", "multilabel", "regression", "sigmoid_regression"],
         default="singlelabel",
     )
-    parser.add_argument("--probe_type", choices=["linear", "transformer", "lyra"], default="linear")
+    parser.add_argument("--probe_type", choices=["mlp", "linear", "transformer", "lyra"], default="mlp")
     parser.add_argument("--no_pre_ln", dest="pre_ln", action="store_false", default=True)
     parser.add_argument("--use_bias", action="store_true")
     parser.add_argument("--tokenwise", action="store_true")
@@ -125,6 +127,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def validate_args(args: argparse.Namespace) -> argparse.Namespace:
+    # Normalize before anything derives a key from it, so a plan built with the former
+    # probe name matches one built with the current name.
+    args.probe_type = normalize_probe_type(args.probe_type)
     assert len(args.model_names) > 0, "At least one model name is required."
     assert len(args.data_names) > 0, "At least one dataset name is required."
     assert args.num_runs > 0, "num_runs must be positive."
@@ -209,7 +214,7 @@ def probe_config_parameter_count(
     args: argparse.Namespace,
     probe_config: ProbePlanConfig,
 ) -> int:
-    if args.probe_type != "linear":
+    if args.probe_type not in ("mlp", "linear"):
         return 0
     return linear_probe_parameter_count(
         input_size=args.input_size,
@@ -227,7 +232,7 @@ def probe_config_recommendation(
 ) -> dict[str, object]:
     parameter_count = probe_config_parameter_count(args, probe_config)
     bytes_per_run = parameter_count * args.dtype_bytes * (2 + args.optimizer_state_multiplier)
-    if args.probe_type == "linear":
+    if args.probe_type in ("mlp", "linear"):
         batch_activation_count = linear_probe_batch_activation_count(
             input_size=args.input_size,
             hidden_size=probe_config.hidden_size,
@@ -295,7 +300,7 @@ def probe_config_recommendation(
         "hidden_size": probe_config.hidden_size,
         "dropout": probe_config.dropout,
         "n_layers": probe_config.n_layers,
-        "parameter_count_known": args.probe_type == "linear",
+        "parameter_count_known": args.probe_type in ("mlp", "linear"),
         "single_probe_parameter_count": parameter_count,
         "training_state_bytes_per_run": bytes_per_run,
         "batch_activation_bytes_per_run": batch_activation_bytes_per_run,

--- a/src/protify/testing_suite/test_esmc_sae_models.py
+++ b/src/protify/testing_suite/test_esmc_sae_models.py
@@ -1,0 +1,273 @@
+"""ESMC SAE model naming, registry entries, and estimator probe construction."""
+
+import pytest
+
+try:
+    from src.protify.base_models.esmc_sae import (
+        DEFAULT_SAE_CODEBOOK_DIM,
+        DEFAULT_SAE_K,
+        ESMC_SAE_COVERAGE,
+        SPARSE_ACTIVE_FRACTION,
+        is_sae_model_name,
+        parse_sae_model_name,
+        resolve_sae_model_name,
+    )
+    from src.protify.base_models.get_base_models import BaseModelArguments
+    from src.protify.base_models.supported_models import (
+        all_presets_with_paths,
+        currently_supported_models,
+    )
+    from src.protify.probes.estimator_probe import (
+        ESTIMATOR_DEFAULTS,
+        ESTIMATOR_PROBE_TYPES,
+        EstimatorProbeArguments,
+        build_estimator,
+        is_estimator_probe,
+    )
+    from src.protify.probes.get_probe import normalize_probe_type
+    from src.protify.base_models.get_base_models import get_base_model_for_training
+except ImportError:
+    from protify.base_models.esmc_sae import (
+        DEFAULT_SAE_CODEBOOK_DIM,
+        DEFAULT_SAE_K,
+        ESMC_SAE_COVERAGE,
+        SPARSE_ACTIVE_FRACTION,
+        is_sae_model_name,
+        parse_sae_model_name,
+        resolve_sae_model_name,
+    )
+    from protify.base_models.get_base_models import BaseModelArguments
+    from protify.base_models.supported_models import (
+        all_presets_with_paths,
+        currently_supported_models,
+    )
+    from protify.probes.estimator_probe import (
+        ESTIMATOR_DEFAULTS,
+        ESTIMATOR_PROBE_TYPES,
+        EstimatorProbeArguments,
+        build_estimator,
+        is_estimator_probe,
+    )
+    from protify.probes.get_probe import normalize_probe_type
+    from protify.base_models.get_base_models import get_base_model_for_training
+
+
+SAE_ALIASES = ("ESMC-300-SAE", "ESMC-600-SAE", "ESMC-6B-SAE")
+
+
+def test_every_alias_is_registered() -> None:
+    for alias in SAE_ALIASES:
+        assert alias in all_presets_with_paths
+        assert alias in currently_supported_models
+
+
+def test_aliases_resolve_to_the_published_depth_layer() -> None:
+    assert resolve_sae_model_name("ESMC-300-SAE") == "ESMC-300-SAE-l23-k64-c8192"
+    assert resolve_sae_model_name("ESMC-600-SAE") == "ESMC-600-SAE-l27-k64-c8192"
+    assert resolve_sae_model_name("ESMC-6B-SAE") == "ESMC-6B-SAE-l60-k64-c8192"
+
+
+def test_default_sparsity_and_width_match_the_resolved_name() -> None:
+    resolved = resolve_sae_model_name("ESMC-300-SAE")
+
+    assert f"-k{DEFAULT_SAE_K}-" in resolved
+    assert resolved.endswith(f"-c{DEFAULT_SAE_CODEBOOK_DIM}")
+
+
+def test_overrides_select_a_different_checkpoint() -> None:
+    resolved = resolve_sae_model_name("ESMC-300-SAE", sae_layer=12, sae_codebook_dim=16384)
+
+    assert resolved == "ESMC-300-SAE-l12-k64-c16384"
+
+
+def test_unpublished_combination_names_the_valid_options() -> None:
+    with pytest.raises(ValueError, match="only publishes k=64 at codebook widths"):
+        resolve_sae_model_name("ESMC-300-SAE", sae_layer=12, sae_codebook_dim=8192)
+
+
+def test_override_contradicting_a_qualified_name_raises() -> None:
+    with pytest.raises(ValueError, match="already fixes its SAE checkpoint"):
+        resolve_sae_model_name("ESMC-300-SAE-l23-k64-c8192", sae_layer=12)
+
+
+def test_qualified_name_passes_through_unchanged() -> None:
+    name = "ESMC-600-SAE-l27-k256-c65536"
+
+    assert resolve_sae_model_name(name) == name
+
+
+def test_parsing_a_qualified_name_yields_the_biohub_checkpoint() -> None:
+    selection = parse_sae_model_name("ESMC-300-SAE-l23-k64-c8192")
+
+    assert selection.repository == "biohub/ESMC-300M-sae-layer23-k64-codebook8192"
+    assert ESMC_SAE_COVERAGE[selection.backbone].model_path == "Synthyra/ESMplusplus_small"
+    assert selection.layer == 23
+    assert selection.codebook_dim == 8192
+
+
+def test_parsing_a_bare_alias_raises() -> None:
+    with pytest.raises(ValueError, match="not a fully qualified"):
+        parse_sae_model_name("ESMC-300-SAE")
+
+
+def test_name_detection_ignores_ordinary_models() -> None:
+    assert is_sae_model_name("ESMC-300-SAE")
+    assert not is_sae_model_name("ESMC-300")
+    assert not is_sae_model_name("ESM2-8")
+
+
+def test_model_arguments_expand_aliases_and_leave_others_alone() -> None:
+    args = BaseModelArguments(model_names=["ESMC-300-SAE", "ESM2-8"], sae_codebook_dim=16384)
+
+    assert args.model_names == ["ESMC-300-SAE-l23-k64-c16384", "ESM2-8"]
+
+
+def test_model_arguments_keep_the_resolved_name_in_entries() -> None:
+    args = BaseModelArguments(model_names=["ESMC-600-SAE"])
+
+    entries = list(args.model_entries())
+    assert entries == [("ESMC-600-SAE-l27-k64-c8192", "ESMC-600-SAE-l27-k64-c8192", None)]
+
+
+def test_estimator_probe_types_are_recognized() -> None:
+    for probe_type in ESTIMATOR_PROBE_TYPES:
+        assert is_estimator_probe(probe_type)
+    assert not is_estimator_probe("mlp")
+    assert not is_estimator_probe("transformer")
+
+
+def test_estimator_defaults_cover_every_estimator_probe_type() -> None:
+    assert set(ESTIMATOR_DEFAULTS) == set(ESTIMATOR_PROBE_TYPES)
+
+
+def test_probe_type_normalization_leaves_estimator_names_alone() -> None:
+    for probe_type in ESTIMATOR_PROBE_TYPES:
+        assert normalize_probe_type(probe_type) == probe_type
+
+
+def test_xgboost_classifier_carries_the_measured_defaults() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(probe_type="xgboost", task_type="singlelabel", num_labels=2)
+    )
+
+    params = estimator.get_params()
+    assert params["learning_rate"] == ESTIMATOR_DEFAULTS["xgboost"]["learning_rate"]
+    assert params["max_depth"] == ESTIMATOR_DEFAULTS["xgboost"]["max_depth"]
+    assert params["early_stopping_rounds"] == 50
+    assert params["objective"] == "binary:logistic"
+
+
+def test_multiclass_targets_switch_the_xgboost_objective() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(probe_type="xgboost", task_type="singlelabel", num_labels=7)
+    )
+
+    assert estimator.get_params()["objective"] == "multi:softprob"
+
+
+def test_regression_builds_a_regressor() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(probe_type="xgboost", task_type="regression")
+    )
+
+    assert type(estimator).__name__ == "XGBRegressor"
+
+
+def test_multilabel_wraps_the_classifier_and_drops_early_stopping() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(probe_type="xgboost", task_type="multilabel", num_labels=4)
+    )
+
+    assert type(estimator).__name__ == "MultiOutputClassifier"
+    assert estimator.estimator.get_params()["early_stopping_rounds"] is None
+
+
+def test_overrides_take_precedence_over_the_defaults() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(
+            probe_type="xgboost", task_type="singlelabel", overrides={"max_depth": 3}
+        )
+    )
+
+    assert estimator.get_params()["max_depth"] == 3
+
+
+def test_seed_reaches_the_estimator() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(probe_type="lightgbm", task_type="singlelabel", seed=1234)
+    )
+
+    assert estimator.get_params()["random_state"] == 1234
+
+
+def test_unknown_estimator_probe_type_raises() -> None:
+    with pytest.raises(ValueError, match="is not an estimator probe"):
+        build_estimator(EstimatorProbeArguments(probe_type="catboost", task_type="singlelabel"))
+
+
+def test_sigmoid_regression_builds_a_regressor() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(probe_type="xgboost", task_type="sigmoid_regression")
+    )
+
+    assert type(estimator).__name__ == "XGBRegressor"
+
+
+def test_tokenwise_tasks_are_refused() -> None:
+    with pytest.raises(ValueError, match="cannot handle task type"):
+        build_estimator(EstimatorProbeArguments(probe_type="xgboost", task_type="tokenwise"))
+
+
+def test_objective_override_survives() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(
+            probe_type="xgboost",
+            task_type="singlelabel",
+            num_labels=2,
+            overrides={"objective": "binary:logitraw"},
+        )
+    )
+
+    assert estimator.get_params()["objective"] == "binary:logitraw"
+
+
+def test_multilabel_overrides_reach_the_wrapped_estimator() -> None:
+    estimator = build_estimator(
+        EstimatorProbeArguments(
+            probe_type="xgboost", task_type="multilabel", num_labels=4, overrides={"max_depth": 5}
+        )
+    )
+
+    assert estimator.estimator.get_params()["max_depth"] == 5
+
+
+def _sparse_storage_for(codebook_dim: int, k: int) -> bool:
+    """The storage policy alone, without loading any checkpoint."""
+    return k / codebook_dim <= SPARSE_ACTIVE_FRACTION
+
+
+def test_storage_policy_matches_the_measured_densities() -> None:
+    # Measured max-pooled density stayed under the break-even for these and exceeded it
+    # for k=256 at codebook 16384, where it reached 56.5% on long proteins.
+    assert _sparse_storage_for(16384, 16)
+    assert _sparse_storage_for(16384, 64)
+    assert not _sparse_storage_for(16384, 256)
+
+
+def test_storage_policy_keeps_the_narrowest_codebook_dense_at_the_default_sparsity() -> None:
+    # Codebook 8192 at k=64 split almost evenly between the formats on real proteins,
+    # and dense was the better single choice.
+    assert not _sparse_storage_for(8192, 64)
+
+
+def test_storage_policy_follows_the_active_fraction_not_the_width_alone() -> None:
+    # Widening the codebook at fixed k lowers the active fraction and turns storage
+    # sparse; raising k at fixed width does the reverse.
+    assert _sparse_storage_for(131072, 64)
+    assert _sparse_storage_for(131072, 512)
+    assert not _sparse_storage_for(8192, 512)
+
+
+def test_sae_models_have_no_trainable_path() -> None:
+    with pytest.raises(ValueError, match="no trainable path"):
+        get_base_model_for_training("ESMC-300-SAE-l23-k64-c8192", num_labels=2)

--- a/src/protify/testing_suite/test_esmc_sae_models.py
+++ b/src/protify/testing_suite/test_esmc_sae_models.py
@@ -129,6 +129,21 @@ def test_model_arguments_keep_the_resolved_name_in_entries() -> None:
     assert entries == [("ESMC-600-SAE-l27-k64-c8192", "ESMC-600-SAE-l27-k64-c8192", None)]
 
 
+def test_sae_models_pool_inside_the_encoder() -> None:
+    # Embedder reads `pools_internally` to skip building a Pooler over SAE outputs. That is
+    # what lets 'sum' through: the generic Pooler owns a different name set and would reject
+    # it before any embedding runs.
+    try:
+        from src.protify.base_models.esmc_sae import SAE_POOLING_TYPES, EsmcSaeForEmbedding
+        from src.protify.pooler import Pooler
+    except ImportError:
+        from protify.base_models.esmc_sae import SAE_POOLING_TYPES, EsmcSaeForEmbedding
+        from protify.pooler import Pooler
+
+    assert EsmcSaeForEmbedding.pools_internally
+    assert set(SAE_POOLING_TYPES) - set(Pooler(['mean']).pooling_options) == {'sum'}
+
+
 def test_estimator_probe_types_are_recognized() -> None:
     for probe_type in ESTIMATOR_PROBE_TYPES:
         assert is_estimator_probe(probe_type)

--- a/src/protify/testing_suite/test_estimator_probe_scores.py
+++ b/src/protify/testing_suite/test_estimator_probe_scores.py
@@ -1,0 +1,105 @@
+"""Score layout the estimator probes hand to the shared metric functions.
+
+Those functions were written for neural probes, so they read their input as raw logits: the
+single-label one softmaxes before computing AUC, and the multi-label one sigmoids before
+thresholding at 0.5. Estimators produce calibrated probabilities instead, so these tests pin
+the inverse transforms, and the multi-label case where a label never varies in training.
+"""
+
+import numpy as np
+import pytest
+
+try:
+    from src.protify.probes.estimator_probe import (
+        EstimatorProbeArguments,
+        _predictions,
+        build_estimator,
+        train_estimator_probe,
+    )
+except ImportError:
+    from protify.probes.estimator_probe import (
+        EstimatorProbeArguments,
+        _predictions,
+        build_estimator,
+        train_estimator_probe,
+    )
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    # x: (n, c)
+    return 1.0 / (1.0 + np.exp(-x))  # (n, c)
+
+
+def _softmax(x: np.ndarray) -> np.ndarray:
+    # x: (n, c)
+    shifted = np.exp(x - x.max(axis=1, keepdims=True))  # (n, c)
+    return shifted / shifted.sum(axis=1, keepdims=True)  # (n, c)
+
+
+@pytest.fixture
+def separable_multilabel():
+    """Two labels a shallow forest separates exactly, from 3 informative features."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(120, 3))  # (n, d)
+    y = np.stack([(X[:, 0] > 0).astype(int), (X[:, 1] > 0).astype(int)], axis=1)  # (n, c)
+    return X, y
+
+
+def test_multilabel_scores_invert_the_metric_sigmoid(separable_multilabel) -> None:
+    X, y = separable_multilabel  # (n, d); (n, c)
+    args = EstimatorProbeArguments(probe_type="random_forest", task_type="multilabel", num_labels=2)
+    estimator = build_estimator(args).fit(X, y)
+
+    scores = _predictions(estimator, X, "multilabel")  # (n, c)
+    positives = np.stack([block[:, 1] for block in estimator.predict_proba(X)], axis=1)  # (n, c)
+
+    assert scores.shape == y.shape
+    assert np.allclose(_sigmoid(scores), positives, atol=1e-6)
+
+
+def test_multilabel_metrics_do_not_collapse_to_all_positive(separable_multilabel) -> None:
+    # Sigmoiding a probability puts every non-zero score above 0.5, which would make the
+    # threshold metrics report an all-ones prediction on data the forest separates exactly.
+    X, y = separable_multilabel  # (n, d); (n, c)
+    args = EstimatorProbeArguments(probe_type="random_forest", task_type="multilabel", num_labels=2)
+    _, valid_metrics, test_metrics = train_estimator_probe(args, X, y, X, y, X, y)
+
+    assert test_metrics["mcc"] > 0.9
+    assert test_metrics["accuracy"] > 0.9
+    assert test_metrics["hamming_loss"] < 0.1
+    assert valid_metrics["mcc"] == test_metrics["mcc"]
+
+
+def test_a_label_constant_in_training_scores_as_negative() -> None:
+    # num_labels counts labels across all three splits, so a label the training split never
+    # sets still gets a column. Its estimator saw one class and cannot predict the other.
+    rng = np.random.default_rng(1)
+    X_train = rng.normal(size=(80, 3))  # (n_train, d)
+    y_train = np.stack(
+        [(X_train[:, 0] > 0).astype(int), np.zeros(80, dtype=int)], axis=1
+    )  # (n_train, c)
+    X_test = rng.normal(size=(20, 3))  # (n_test, d)
+    y_test = np.stack([(X_test[:, 0] > 0).astype(int), np.ones(20, dtype=int)], axis=1)  # (n_test, c)
+
+    args = EstimatorProbeArguments(probe_type="random_forest", task_type="multilabel", num_labels=2)
+    estimator = build_estimator(args).fit(X_train, y_train)
+
+    scores = _predictions(estimator, X_test, "multilabel")  # (n_test, c)
+
+    assert scores.shape == y_test.shape
+    assert np.allclose(_sigmoid(scores)[:, 1], 0.0, atol=1e-6)
+
+
+def test_single_label_scores_invert_the_metric_softmax() -> None:
+    rng = np.random.default_rng(2)
+    X = rng.normal(size=(120, 3))  # (n, d)
+    y = np.digitize(X[:, 0], [-0.5, 0.5])  # (n,); three ordered classes
+
+    args = EstimatorProbeArguments(probe_type="random_forest", task_type="singlelabel", num_labels=3)
+    estimator = build_estimator(args).fit(X, y)
+
+    scores = _predictions(estimator, X, "singlelabel")  # (n, c)
+
+    # Log probabilities sum to one after softmax, so the metric recovers them exactly rather
+    # than distorting the one-vs-rest ranking the multiclass AUC reads.
+    assert np.allclose(_softmax(scores), estimator.predict_proba(X), atol=1e-6)

--- a/src/protify/testing_suite/test_numpy_dataset_matrix_embeddings.py
+++ b/src/protify/testing_suite/test_numpy_dataset_matrix_embeddings.py
@@ -1,0 +1,91 @@
+"""Matrix embeddings feeding the numpy dataset the estimator and scikit probes consume.
+
+These learners take one vector per sequence, so a per-residue cache has to be reduced on
+the way in. The stored matrix keeps the leading and trailing special tokens, so it has
+len(seq)+2 rows and cannot be reshaped against the sequence length.
+"""
+
+import types
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from src.protify.data.data_mixin import DataMixin
+except ImportError:
+    try:
+        from protify.data.data_mixin import DataMixin
+    except ImportError:
+        from ..data.data_mixin import DataMixin
+
+
+POOLING_TYPES = ['max']
+HIDDEN_STATE_INDEX = -1
+HIDDEN_SIZE = 3  # d
+
+SEQ_A = 'AAAA'
+SEQ_B = 'CCCCCCC'
+
+
+def _residue_matrix(seq: str, offset: float) -> torch.Tensor:
+    """One cached matrix embedding, special tokens included."""
+    rows = len(seq) + 2  # l
+    values = torch.arange(rows * HIDDEN_SIZE, dtype=torch.float32) + offset
+    return values.reshape(rows, HIDDEN_SIZE)  # (l, d)
+
+
+@pytest.fixture
+def matrix_mixin(tmp_path):
+    """A DataMixin whose only embedding source is a two-protein matrix .pth cache."""
+    from protify.embedder import get_embedding_filename
+
+    embeddings = {SEQ_A: _residue_matrix(SEQ_A, 0.0), SEQ_B: _residue_matrix(SEQ_B, 100.0)}
+    filename = get_embedding_filename('test-model', True, POOLING_TYPES, 'pth', HIDDEN_STATE_INDEX)
+    torch.save(embeddings, tmp_path / filename)
+
+    mixin = DataMixin()
+    mixin._sql = False
+    mixin._full = True
+    mixin.embedding_args = types.SimpleNamespace(
+        embedding_save_dir=str(tmp_path),
+        pooling_types=POOLING_TYPES,
+        hidden_state_index=HIDDEN_STATE_INDEX,
+    )
+    return mixin
+
+
+def test_matrix_embeddings_average_to_one_row_per_sequence(matrix_mixin) -> None:
+    # Sequences of different lengths have to land in the same matrix, which rules out any
+    # layout that keeps a per-residue axis.
+    X_train, X_valid, X_test = matrix_mixin.build_vector_numpy_dataset_from_embeddings(
+        'test-model', [SEQ_A, SEQ_B], [SEQ_A], [SEQ_B]
+    )
+
+    assert X_train.shape == (2, HIDDEN_SIZE)
+    assert X_valid.shape == (1, HIDDEN_SIZE)
+    assert X_test.shape == (1, HIDDEN_SIZE)
+
+    expected_a = _residue_matrix(SEQ_A, 0.0).mean(dim=0).numpy()  # (d,)
+    expected_b = _residue_matrix(SEQ_B, 100.0).mean(dim=0).numpy()  # (d,)
+    assert np.allclose(X_train[0], expected_a)
+    assert np.allclose(X_train[1], expected_b)
+    assert np.allclose(X_valid[0], expected_a)
+    assert np.allclose(X_test[0], expected_b)
+
+
+def test_matrix_pair_embeddings_concatenate_two_averaged_vectors(matrix_mixin) -> None:
+    X_train, _, _ = matrix_mixin.build_pair_vector_numpy_dataset_from_embeddings(
+        'test-model',
+        [SEQ_A], [SEQ_B],
+        [SEQ_A], [SEQ_B],
+        [SEQ_A], [SEQ_B],
+    )
+
+    assert X_train.shape == (1, 2 * HIDDEN_SIZE)
+
+    expected = np.concatenate([
+        _residue_matrix(SEQ_A, 0.0).mean(dim=0).numpy(),  # (d,)
+        _residue_matrix(SEQ_B, 100.0).mean(dim=0).numpy(),  # (d,)
+    ])  # (2 * d,)
+    assert np.allclose(X_train[0], expected)

--- a/src/protify/testing_suite/test_packaged_probe_export.py
+++ b/src/protify/testing_suite/test_packaged_probe_export.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from transformers import AutoModel, BertConfig, BertModel, BertTokenizerFast
 
 try:
-    from probes.linear_probe import LinearProbe, LinearProbeConfig
+    from probes.mlp_probe import MLPProbe, MLPProbeConfig
     from probes.packaged_probe_model import PackagedProbeConfig, PackagedProbeModel
     from probes.transformer_probe import TransformerForSequenceClassification, TransformerProbeConfig
 except ImportError:
-    from ..probes.linear_probe import LinearProbe, LinearProbeConfig
+    from ..probes.mlp_probe import MLPProbe, MLPProbeConfig
     from ..probes.packaged_probe_model import PackagedProbeConfig, PackagedProbeModel
     from ..probes.transformer_probe import TransformerForSequenceClassification, TransformerProbeConfig
 
@@ -92,7 +92,7 @@ def test_linear_packaged_roundtrip() -> None:
         model_dir.mkdir(parents=True, exist_ok=True)
 
         backbone, tokenizer = _create_tiny_backbone(backbone_dir)
-        probe_config = LinearProbeConfig(
+        probe_config = MLPProbeConfig(
             input_size=16,
             hidden_size=32,
             dropout=0.1,
@@ -100,10 +100,10 @@ def test_linear_packaged_roundtrip() -> None:
             n_layers=1,
             task_type="singlelabel",
         )
-        probe = LinearProbe(probe_config).eval()
+        probe = MLPProbe(probe_config).eval()
         packaged_config = PackagedProbeConfig(
             base_model_name=str(backbone_dir),
-            probe_type="linear",
+            probe_type="mlp",
             probe_config=probe.config.to_dict(),
             tokenwise=False,
             matrix_embed=False,
@@ -198,7 +198,7 @@ def test_ppi_packaged_inference_with_and_without_token_type_ids() -> None:
         model_dir.mkdir(parents=True, exist_ok=True)
 
         backbone, tokenizer = _create_tiny_backbone(backbone_dir)
-        probe_config = LinearProbeConfig(
+        probe_config = MLPProbeConfig(
             input_size=32,
             hidden_size=24,
             dropout=0.1,
@@ -206,10 +206,10 @@ def test_ppi_packaged_inference_with_and_without_token_type_ids() -> None:
             n_layers=1,
             task_type="singlelabel",
         )
-        probe = LinearProbe(probe_config).eval()
+        probe = MLPProbe(probe_config).eval()
         packaged_config = PackagedProbeConfig(
             base_model_name=str(backbone_dir),
-            probe_type="linear",
+            probe_type="mlp",
             probe_config=probe.config.to_dict(),
             tokenwise=False,
             matrix_embed=False,

--- a/src/protify/testing_suite/test_pair_numpy_dataset.py
+++ b/src/protify/testing_suite/test_pair_numpy_dataset.py
@@ -1,0 +1,108 @@
+"""Pair ordering in the numpy dataset the estimator and scikit probes consume.
+
+Interaction is symmetric, but concatenating A with B is not, so swapping the two proteins
+is a training augmentation. Doing it on validation or test instead makes a reported score
+depend on the random state, which these tests pin down.
+"""
+
+import random
+import types
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from src.protify.data.data_mixin import DataMixin
+except ImportError:
+    try:
+        from protify.data.data_mixin import DataMixin
+    except ImportError:
+        from ..data.data_mixin import DataMixin
+
+
+POOLING_TYPES = ['max']
+HIDDEN_STATE_INDEX = -1
+
+SEQ_A = 'AAAA'
+SEQ_B = 'CCCC'
+
+
+@pytest.fixture
+def mixin(tmp_path):
+    """A DataMixin whose only embedding source is a two-protein .pth cache."""
+    from protify.embedder import get_embedding_filename
+
+    # One distinguishing value per protein, so a swap is visible in the concatenated row.
+    embeddings = {
+        SEQ_A: torch.tensor([1.0, 2.0]),  # (d,), d = 2
+        SEQ_B: torch.tensor([30.0, 40.0]),  # (d,)
+    }
+    filename = get_embedding_filename('test-model', False, POOLING_TYPES, 'pth', HIDDEN_STATE_INDEX)
+    torch.save(embeddings, tmp_path / filename)
+
+    mixin = DataMixin()
+    mixin._sql = False
+    mixin._full = False
+    mixin.embedding_args = types.SimpleNamespace(
+        embedding_save_dir=str(tmp_path),
+        pooling_types=POOLING_TYPES,
+        hidden_state_index=HIDDEN_STATE_INDEX,
+    )
+    return mixin
+
+
+def build(mixin, flip_train_pairs, pair_count=64):
+    """Build train, validation, and test matrices from the same repeated pair."""
+    seqs_a = [SEQ_A] * pair_count
+    seqs_b = [SEQ_B] * pair_count
+    return mixin.build_pair_vector_numpy_dataset_from_embeddings(
+        'test-model',
+        seqs_a, seqs_b,
+        seqs_a, seqs_b,
+        seqs_a, seqs_b,
+        flip_train_pairs=flip_train_pairs,
+    )  # three arrays, each (pair_count, 2 * d)
+
+
+def test_evaluation_splits_keep_dataset_pair_order_when_flipping(mixin):
+    random.seed(0)
+    _, X_valid, X_test = build(mixin, flip_train_pairs=True)  # (n, 2 * d) each
+
+    forward = np.array([1.0, 2.0, 30.0, 40.0])  # (2 * d,)
+    assert np.array_equal(X_valid, np.tile(forward, (X_valid.shape[0], 1)))
+    assert np.array_equal(X_test, np.tile(forward, (X_test.shape[0], 1)))
+
+
+def test_evaluation_splits_are_independent_of_the_random_state(mixin):
+    random.seed(0)
+    _, first_valid, first_test = build(mixin, flip_train_pairs=True)
+    random.seed(12345)
+    _, second_valid, second_test = build(mixin, flip_train_pairs=True)
+
+    assert np.array_equal(first_valid, second_valid)
+    assert np.array_equal(first_test, second_test)
+
+
+def test_training_pairs_swap_only_when_flipping_is_requested(mixin):
+    random.seed(0)
+    flipped_train, _, _ = build(mixin, flip_train_pairs=True)  # (n, 2 * d)
+    reversed_row = np.array([30.0, 40.0, 1.0, 2.0])  # (2 * d,)
+    swapped = (flipped_train == reversed_row).all(axis=1)  # (n,)
+    assert swapped.any(), 'flipping requested but no training pair was swapped'
+    assert not swapped.all(), 'flipping should leave some training pairs in dataset order'
+
+    unflipped_train, _, _ = build(mixin, flip_train_pairs=False)
+    forward = np.array([1.0, 2.0, 30.0, 40.0])  # (2 * d,)
+    assert np.array_equal(unflipped_train, np.tile(forward, (unflipped_train.shape[0], 1)))
+
+
+def test_flipping_defaults_to_off(mixin):
+    random.seed(0)
+    seqs_a, seqs_b = [SEQ_A] * 64, [SEQ_B] * 64
+    X_train, _, _ = mixin.build_pair_vector_numpy_dataset_from_embeddings(
+        'test-model', seqs_a, seqs_b, seqs_a, seqs_b, seqs_a, seqs_b,
+    )  # (n, 2 * d)
+
+    forward = np.array([1.0, 2.0, 30.0, 40.0])  # (2 * d,)
+    assert np.array_equal(X_train, np.tile(forward, (X_train.shape[0], 1)))

--- a/src/protify/testing_suite/test_parallel_linear_probe.py
+++ b/src/protify/testing_suite/test_parallel_linear_probe.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 try:
     from src.protify import probes as probes_package
     from src.protify.probes import trainers as trainers_module
-    from src.protify.probes.linear_probe import LinearProbe, LinearProbeConfig
+    from src.protify.probes.mlp_probe import MLPProbe, MLPProbeConfig
     from src.protify.probes.parallel_linear_probe import (
         ParallelLinearProbe,
         ParallelLinearProbeConfig,
@@ -27,7 +27,7 @@ except ImportError:
     try:
         from protify import probes as probes_package
         from protify.probes import trainers as trainers_module
-        from protify.probes.linear_probe import LinearProbe, LinearProbeConfig
+        from protify.probes.mlp_probe import MLPProbe, MLPProbeConfig
         from protify.probes.parallel_linear_probe import (
             ParallelLinearProbe,
             ParallelLinearProbeConfig,
@@ -44,7 +44,7 @@ except ImportError:
     except ImportError:
         from .. import probes as probes_package
         from ..probes import trainers as trainers_module
-        from ..probes.linear_probe import LinearProbe, LinearProbeConfig
+        from ..probes.mlp_probe import MLPProbe, MLPProbeConfig
         from ..probes.parallel_linear_probe import (
             ParallelLinearProbe,
             ParallelLinearProbeConfig,
@@ -72,7 +72,7 @@ def _trainer_mixin_for_parallel_tests(task_type: str = 'singlelabel') -> Trainer
     mixin = TrainerMixin(trainer_args=trainer_args)
     mixin.embedding_args = SimpleNamespace(matrix_embed=False)
     mixin.probe_args = SimpleNamespace(
-        probe_type='linear',
+        probe_type='mlp',
         tokenwise=False,
         input_size=4,
         hidden_size=8,
@@ -170,7 +170,7 @@ def test_parallel_linear_probe_exports_matching_single_run_probe() -> None:
         run_seeds=[101, 102, 103],
     )
     parallel_probe = ParallelLinearProbe(config).eval()
-    single_probe = parallel_probe.to_linear_probe(1).eval()
+    single_probe = parallel_probe.to_mlp_probe(1).eval()
     embeddings = torch.randn(9, 6)
 
     parallel_logits = parallel_probe(embeddings=embeddings).logits[:, 1, :]
@@ -208,7 +208,7 @@ def test_parallel_linear_probe_ensemble_matches_average_exported_single_probes(t
     ensemble_logits = ensemble(embeddings=embeddings).logits
     single_logits = []
     for run_idx in range(config.num_runs):
-        single_probe = parallel_probe.to_linear_probe(run_idx).eval()
+        single_probe = parallel_probe.to_mlp_probe(run_idx).eval()
         single_logits.append(single_probe(embeddings=embeddings).logits)
     expected = torch.stack(single_logits, dim=1).mean(dim=1)
 
@@ -235,8 +235,8 @@ def test_parallel_linear_probe_ensemble_can_average_selected_runs() -> None:
     output = ensemble(embeddings=embeddings)
     expected = torch.stack(
         [
-            parallel_probe.to_linear_probe(1).eval()(embeddings=embeddings).logits,
-            parallel_probe.to_linear_probe(3).eval()(embeddings=embeddings).logits,
+            parallel_probe.to_mlp_probe(1).eval()(embeddings=embeddings).logits,
+            parallel_probe.to_mlp_probe(3).eval()(embeddings=embeddings).logits,
         ],
         dim=1,
     ).mean(dim=1)
@@ -265,7 +265,7 @@ def test_parallel_linear_probe_ensemble_accepts_run_specific_embeddings() -> Non
     output = ensemble(embeddings=embeddings)
     expected = torch.stack(
         [
-            parallel_probe.to_linear_probe(run_idx).eval()(embeddings=embeddings[:, run_idx, :]).logits
+            parallel_probe.to_mlp_probe(run_idx).eval()(embeddings=embeddings[:, run_idx, :]).logits
             for run_idx in range(config.num_runs)
         ],
         dim=1,
@@ -366,8 +366,8 @@ def test_parallel_linear_probe_seeded_run_matches_linear_probe_initialization() 
     parallel_probe = ParallelLinearProbe(config).eval()
     with torch.random.fork_rng(devices=[]):
         torch.manual_seed(seed)
-        single_probe = LinearProbe(
-            LinearProbeConfig(
+        single_probe = MLPProbe(
+            MLPProbeConfig(
                 input_size=5,
                 hidden_size=7,
                 dropout=0.0,
@@ -453,7 +453,7 @@ def test_parallel_linear_probe_shared_eval_matches_exported_single_probes(task_t
     parallel_output = parallel_probe(embeddings=embeddings, labels=shared_labels)
     single_losses = []
     for run_idx in range(config.num_runs):
-        single_probe = parallel_probe.to_linear_probe(run_idx).eval()
+        single_probe = parallel_probe.to_mlp_probe(run_idx).eval()
         single_output = single_probe(embeddings=embeddings, labels=shared_labels)
         assert torch.allclose(parallel_output.logits[:, run_idx, :], single_output.logits, atol=1e-6)
         single_losses.append(single_output.loss)
@@ -491,7 +491,7 @@ def test_parallel_linear_probe_run_specific_eval_matches_exported_single_probes(
     parallel_output = parallel_probe(embeddings=embeddings, labels=run_labels)
     single_losses = []
     for run_idx in range(config.num_runs):
-        single_probe = parallel_probe.to_linear_probe(run_idx).eval()
+        single_probe = parallel_probe.to_mlp_probe(run_idx).eval()
         if task_type == 'singlelabel':
             single_labels = run_labels[:, run_idx]
         elif task_type == 'multilabel':
@@ -538,7 +538,7 @@ def test_parallel_linear_probe_accepts_run_specific_batches() -> None:
     assert output.loss.ndim == 0
     assert torch.isfinite(output.loss)
     for run_idx in range(config.num_runs):
-        single_probe = parallel_probe.to_linear_probe(run_idx).eval()
+        single_probe = parallel_probe.to_mlp_probe(run_idx).eval()
         single_logits = single_probe(embeddings=embeddings[:, run_idx, :]).logits
         assert torch.allclose(output.logits[:, run_idx, :], single_logits, atol=1e-6)
 
@@ -829,7 +829,7 @@ def test_parallel_linear_probe_sigmoid_regression_ignores_masked_shared_labels()
     output = parallel_probe(embeddings=embeddings, labels=labels)
     single_losses = []
     for run_idx in range(config.num_runs):
-        single_probe = parallel_probe.to_linear_probe(run_idx).eval()
+        single_probe = parallel_probe.to_mlp_probe(run_idx).eval()
         single_output = single_probe(embeddings=embeddings, labels=labels)
         single_losses.append(single_output.loss)
 
@@ -863,7 +863,7 @@ def test_parallel_linear_probe_sigmoid_regression_ignores_masked_run_specific_la
     output = parallel_probe(embeddings=embeddings, labels=labels)
     single_losses = []
     for run_idx in range(config.num_runs):
-        single_probe = parallel_probe.to_linear_probe(run_idx).eval()
+        single_probe = parallel_probe.to_mlp_probe(run_idx).eval()
         single_output = single_probe(
             embeddings=embeddings[:, run_idx, :],
             labels=labels[:, run_idx],
@@ -885,7 +885,7 @@ def test_parallel_probe_trainer_eligibility_gate() -> None:
 
     mixin.probe_args.probe_type = 'transformer'
     assert not mixin._can_parallelize_probe_runs(full=False)
-    mixin.probe_args.probe_type = 'linear'
+    mixin.probe_args.probe_type = 'mlp'
 
     assert not mixin._can_parallelize_probe_runs(full=True)
 
@@ -1333,7 +1333,7 @@ def test_parallel_trainer_reports_parallel_execution_metadata(monkeypatch) -> No
         data_name='data',
     )
 
-    assert isinstance(model, LinearProbe)
+    assert isinstance(model, MLPProbe)
     assert test_metrics['training_time_seconds'] == pytest.approx(8.0)
     assert test_metrics['parallel_probe_num_runs'] == 2
     assert test_metrics['parallel_probe_seconds_per_run'] == pytest.approx(4.0)
@@ -1481,7 +1481,7 @@ def test_parallel_trainer_chunks_seed_groups_and_aggregates_metadata(monkeypatch
         data_name='data',
     )
 
-    assert isinstance(model, LinearProbe)
+    assert isinstance(model, MLPProbe)
     assert captured['groups'] == [[42, 43], [44, 45], [46]]
     assert captured['output_dirs'][0].endswith('parallel_group_1')
     assert captured['output_dirs'][1].endswith('parallel_group_2')
@@ -1588,8 +1588,8 @@ def test_parallel_trainer_uses_budget_derived_group_size(monkeypatch) -> None:
 
     mixin = _trainer_mixin_for_parallel_tests()
     mixin.trainer_args.num_runs = 5
-    probe = LinearProbe(
-        LinearProbeConfig(
+    probe = MLPProbe(
+        MLPProbeConfig(
             input_size=mixin.probe_args.input_size,
             hidden_size=mixin.probe_args.hidden_size,
             dropout=mixin.probe_args.dropout,
@@ -1694,8 +1694,8 @@ def test_parallel_trainer_uses_estimated_peak_budget_derived_group_size(monkeypa
 
     mixin = _trainer_mixin_for_parallel_tests()
     mixin.trainer_args.num_runs = 5
-    probe = LinearProbe(
-        LinearProbeConfig(
+    probe = MLPProbe(
+        MLPProbeConfig(
             input_size=mixin.probe_args.input_size,
             hidden_size=mixin.probe_args.hidden_size,
             dropout=mixin.probe_args.dropout,
@@ -1827,7 +1827,7 @@ def test_parallel_trainer_saves_exported_best_probe_when_enabled(monkeypatch) ->
         data_name='data',
     )
 
-    assert isinstance(captured['best_model'], LinearProbe)
+    assert isinstance(captured['best_model'], MLPProbe)
     assert captured['test_metrics'] is test_metrics
     assert captured['test_metrics']['parallel_probe_best_seed'] == 42
     assert captured['log_id'] == 'log'

--- a/src/protify/testing_suite/test_parallel_probe_logger.py
+++ b/src/protify/testing_suite/test_parallel_probe_logger.py
@@ -56,7 +56,7 @@ def test_probe_result_identity_fields_are_written_to_results_tsv(tmp_path) -> No
         log_dir=str(tmp_path / "logs"),
         results_dir=str(tmp_path / "results"),
         replay_path=None,
-        probe_type="linear",
+        probe_type="mlp",
         hidden_size=64,
         dropout=0.2,
         n_layers=0,
@@ -76,7 +76,7 @@ def test_probe_result_identity_fields_are_written_to_results_tsv(tmp_path) -> No
     )
 
     stored = logger.logger_data_tracking["EC"]["ESM2-35"]
-    assert stored["probe_type"] == "linear"
+    assert stored["probe_type"] == "mlp"
     assert stored["hidden_size"] == 64
     assert stored["dropout"] == 0.2
     assert stored["n_layers"] == 0
@@ -86,7 +86,7 @@ def test_probe_result_identity_fields_are_written_to_results_tsv(tmp_path) -> No
     with open(logger.results_file, "r", newline="", encoding="utf-8") as handle:
         rows = list(csv.reader(handle, delimiter="\t"))
     metrics = json.loads(rows[1][1])
-    assert metrics["probe_type"] == "linear"
+    assert metrics["probe_type"] == "mlp"
     assert metrics["hidden_size"] == 64
     assert metrics["dropout"] == 0.2
     assert metrics["n_layers"] == 0

--- a/src/protify/testing_suite/test_parallel_probe_plan.py
+++ b/src/protify/testing_suite/test_parallel_probe_plan.py
@@ -4,7 +4,7 @@ import pytest
 
 try:
     from src.protify import probes as probes_package
-    from src.protify.probes.linear_probe import LinearProbe, LinearProbeConfig
+    from src.protify.probes.mlp_probe import MLPProbe, MLPProbeConfig
     from src.protify.probes.parallel_probe_plan import (
         ParallelProbeExecutionPlan,
         ParallelProbeGroup,
@@ -29,7 +29,7 @@ try:
 except ImportError:
     try:
         from protify import probes as probes_package
-        from protify.probes.linear_probe import LinearProbe, LinearProbeConfig
+        from protify.probes.mlp_probe import MLPProbe, MLPProbeConfig
         from protify.probes.parallel_probe_plan import (
             ParallelProbeExecutionPlan,
             ParallelProbeGroup,
@@ -53,7 +53,7 @@ except ImportError:
         )
     except ImportError:
         from .. import probes as probes_package
-        from ..probes.linear_probe import LinearProbe, LinearProbeConfig
+        from ..probes.mlp_probe import MLPProbe, MLPProbeConfig
         from ..probes.parallel_probe_plan import (
             ParallelProbeExecutionPlan,
             ParallelProbeGroup,
@@ -86,7 +86,7 @@ def _run_spec(run_id: str = 'run-0', seed: int = 7) -> ParallelProbeRunSpec:
         embedding_key='ESM2-35/EC/mean/v1',
         dataset_key='EC/split/v1',
         trainer_key='epochs=1|batch=8|lr=1e-4',
-        probe_type='linear',
+        probe_type='mlp',
         input_size=8,
         hidden_size=4,
         dropout=0.0,
@@ -155,7 +155,7 @@ def test_build_seed_run_specs_groups_into_one_vectorized_group() -> None:
         embedding_key='ESM2-35/EC/mean/v1',
         dataset_key='EC/split/v1',
         trainer_key='epochs=1|batch=8|lr=1e-4',
-        probe_type='linear',
+        probe_type='mlp',
         input_size=8,
         hidden_size=4,
         dropout=0.0,
@@ -325,7 +325,7 @@ def test_parallel_probe_plan_rejects_invalid_max_group_size() -> None:
 
 
 def test_linear_probe_parameter_count_matches_actual_model_parameters() -> None:
-    config = LinearProbeConfig(
+    config = MLPProbeConfig(
         input_size=8,
         hidden_size=4,
         dropout=0.0,
@@ -335,7 +335,7 @@ def test_linear_probe_parameter_count_matches_actual_model_parameters() -> None:
         pre_ln=True,
         use_bias=True,
     )
-    model = LinearProbe(config)
+    model = MLPProbe(config)
     expected = sum(parameter.numel() for parameter in model.parameters())
 
     observed = linear_probe_parameter_count(
@@ -595,7 +595,7 @@ def test_build_seed_run_specs_rejects_empty_run_sets() -> None:
             embedding_key='ESM2-35/EC/mean/v1',
             dataset_key='EC/split/v1',
             trainer_key='epochs=1|batch=8|lr=1e-4',
-            probe_type='linear',
+            probe_type='mlp',
             input_size=8,
             hidden_size=4,
             dropout=0.0,
@@ -780,7 +780,7 @@ def test_wave_schedule_rejects_invalid_packing_args() -> None:
         embedding_key='ESM2-35/EC/mean/v1',
         dataset_key='EC/split/v1',
         trainer_key='epochs=1|batch=8|lr=1e-4',
-        probe_type='linear',
+        probe_type='mlp',
         input_size=8,
         hidden_size=4,
         dropout=0.0,

--- a/src/protify/testing_suite/test_parallel_probe_preflight.py
+++ b/src/protify/testing_suite/test_parallel_probe_preflight.py
@@ -354,7 +354,7 @@ def test_parallel_probe_preflight_builds_cross_product_plan_report() -> None:
     assert report["groups"][0]["data_name"] == "EC"
     assert report["groups"][0]["embedding_key"] == "ESM2-35/EC/pooled"
     assert report["groups"][0]["dataset_key"] == "EC/default"
-    assert report["groups"][0]["probe_type"] == "linear"
+    assert report["groups"][0]["probe_type"] == "mlp"
     assert report["groups"][0]["input_size"] == 320
     assert report["groups"][0]["hidden_size"] == 64
     assert report["groups"][0]["dropout"] == 0.2
@@ -422,7 +422,7 @@ def test_parallel_probe_preflight_builds_cross_product_plan_report() -> None:
         "--data_names",
         "EC",
         "--probe_type",
-        "linear",
+        "mlp",
         "--hidden_size",
         "64",
         "--dropout",
@@ -448,7 +448,7 @@ def test_parallel_probe_preflight_builds_cross_product_plan_report() -> None:
         "--data_names",
         "EC",
         "--probe_type",
-        "linear",
+        "mlp",
         "--hidden_size",
         "64",
         "--dropout",

--- a/src/protify/testing_suite/test_pooler.py
+++ b/src/protify/testing_suite/test_pooler.py
@@ -119,9 +119,34 @@ def test_var_no_mask(emb: torch.Tensor) -> None:
     # emb: (b, l, d)
     pooler = Pooler(['var'])
     pooled = pooler.var_pooling(emb)  # (b, d)
-    expected = emb.var(dim=1)  # (b, d)
+    expected = emb.var(dim=1, unbiased=False)  # (b, d)
     assert pooled.shape == (batch_size, hidden_size)
     assert torch.allclose(pooled, expected)
+
+
+def test_var_pooling_agrees_with_and_without_a_mask(emb: torch.Tensor) -> None:
+    # emb: (b, l, d). A full mask must give the same answer as no mask at all, which
+    # needs both branches to use the population variance.
+    pooler = Pooler(['var'])
+    full_mask = torch.ones(emb.shape[0], emb.shape[1])  # (b, l)
+
+    assert torch.allclose(
+        pooler(emb),  # (b, d)
+        pooler(emb, attention_mask=full_mask),  # (b, d)
+        atol=1e-5,
+    )
+
+
+def test_std_equals_sqrt_var_without_a_mask(emb: torch.Tensor) -> None:
+    # emb: (b, l, d). PackagedProbeModel pools with no mask, so the unmasked branches of
+    # std and var have to agree the same way the masked ones do.
+    pooler = Pooler(['std'])
+
+    assert torch.allclose(
+        pooler.std_pooling(emb),  # (b, d)
+        torch.sqrt(pooler.var_pooling(emb)),  # (b, d)
+        atol=1e-6,
+    )
 
 
 def test_var_with_mask(emb: torch.Tensor, mask: torch.Tensor) -> None:

--- a/src/protify/testing_suite/test_pooler.py
+++ b/src/protify/testing_suite/test_pooler.py
@@ -192,3 +192,26 @@ def test_call_multiple_types_concat(
     pooler = Pooler(types)
     pooled = pooler(emb, attention_mask=mask)  # (b, 3d)
     assert pooled.shape == (batch_size, len(types) * hidden_size)
+
+
+def test_unknown_pooling_type_is_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="Unknown pooling types"):
+        Pooler(['mean', 'nonexistent'])
+
+
+def test_repeated_pooling_type_is_rejected() -> None:
+    with pytest.raises(ValueError, match="appear more than once"):
+        Pooler(['mean', 'max', 'mean'])
+
+
+def test_std_pooling_agrees_with_and_without_a_mask(emb: torch.Tensor) -> None:
+    # emb: (b, l, d). A full mask must give the same answer as no mask at all, which
+    # needs both branches to use the population standard deviation.
+    pooler = Pooler(['std'])
+    full_mask = torch.ones(emb.shape[0], emb.shape[1])  # (b, l)
+
+    assert torch.allclose(
+        pooler(emb),  # (b, d)
+        pooler(emb, attention_mask=full_mask),  # (b, d)
+        atol=1e-5,
+    )

--- a/src/protify/testing_suite/test_probe_construction.py
+++ b/src/protify/testing_suite/test_probe_construction.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from src.protify.probes.get_probe import ProbeArguments, get_probe, rebuild_probe_from_saved_config
-    from src.protify.probes.linear_probe import LinearProbe
+    from src.protify.probes.mlp_probe import MLPProbe
     from src.protify.probes.transformer_probe import (
         TransformerForSequenceClassification, TransformerForTokenClassification,
     )
@@ -13,14 +13,14 @@ try:
 except ImportError:
     try:
         from protify.probes.get_probe import ProbeArguments, get_probe, rebuild_probe_from_saved_config
-        from protify.probes.linear_probe import LinearProbe
+        from protify.probes.mlp_probe import MLPProbe
         from protify.probes.transformer_probe import (
             TransformerForSequenceClassification, TransformerForTokenClassification,
         )
         from protify.probes.lyra_probe import LyraForSequenceClassification, LyraForTokenClassification
     except ImportError:
         from ..probes.get_probe import ProbeArguments, get_probe, rebuild_probe_from_saved_config
-        from ..probes.linear_probe import LinearProbe
+        from ..probes.mlp_probe import MLPProbe
         from ..probes.transformer_probe import (
             TransformerForSequenceClassification, TransformerForTokenClassification,
         )
@@ -52,10 +52,17 @@ def _make_args(**kwargs) -> ProbeArguments:
     return ProbeArguments(**defaults)
 
 
-def test_get_probe_linear_sequence() -> None:
-    args = _make_args(probe_type="linear", tokenwise=False)
+def test_get_probe_mlp_sequence() -> None:
+    args = _make_args(probe_type="mlp", tokenwise=False)
     probe = get_probe(args)
-    assert isinstance(probe, LinearProbe)
+    assert isinstance(probe, MLPProbe)
+
+
+def test_probe_type_linear_still_selects_the_mlp_probe() -> None:
+    # "linear" is the former name and appears in saved configs and existing YAML.
+    args = _make_args(probe_type="linear", tokenwise=False)
+    assert args.probe_type == "mlp"
+    assert isinstance(get_probe(args), MLPProbe)
 
 
 def test_get_probe_transformer_sequence() -> None:
@@ -147,7 +154,7 @@ def test_rebuild_probe_from_saved_config_linear() -> None:
     original = get_probe(args)
     config_dict = original.config.to_dict()
     rebuilt = rebuild_probe_from_saved_config("linear", False, config_dict)
-    assert isinstance(rebuilt, LinearProbe)
+    assert isinstance(rebuilt, MLPProbe)
     assert rebuilt.config.num_labels == 3
 
 

--- a/src/protify/testing_suite/test_sparse_blob_serialization.py
+++ b/src/protify/testing_suite/test_sparse_blob_serialization.py
@@ -1,0 +1,189 @@
+"""Coordinate-list blob storage and bfloat16 fidelity for embedding blobs."""
+
+import struct
+
+import torch
+
+try:
+    from src.protify.utils import (
+        _COMPACT_VERSION,
+        _SPARSE_VERSION,
+        batch_tensor_to_blobs,
+        embedding_blob_to_tensor,
+        tensor_to_embedding_blob,
+    )
+except ImportError:
+    try:
+        from protify.utils import (
+            _COMPACT_VERSION,
+            _SPARSE_VERSION,
+            batch_tensor_to_blobs,
+            embedding_blob_to_tensor,
+            tensor_to_embedding_blob,
+        )
+    except ImportError:
+        from ..utils import (
+            _COMPACT_VERSION,
+            _SPARSE_VERSION,
+            batch_tensor_to_blobs,
+            embedding_blob_to_tensor,
+            tensor_to_embedding_blob,
+        )
+
+
+def _sparse_vector(width: int, density: float, dtype: torch.dtype = torch.float16) -> torch.Tensor:
+    """A codebook-shaped vector with a fixed fraction of non-zero entries."""
+    torch.manual_seed(width)
+    vector = torch.zeros(width, dtype=dtype)  # (w,)
+    active = torch.randperm(width)[: int(density * width)]  # (nnz,)
+    vector[active] = torch.rand(len(active)).to(dtype) + 0.1  # (nnz,)
+    return vector  # (w,)
+
+
+def test_sparse_flag_selects_the_coordinate_list_format() -> None:
+    # Measured max-pooled density for ESMC SAE features at codebook width 131072.
+    blob = tensor_to_embedding_blob(_sparse_vector(131072, 0.036), sparse=True)
+
+    assert blob[0] == _SPARSE_VERSION
+
+
+def test_embeddings_stay_dense_unless_asked() -> None:
+    # A sparse tensor still stores dense when the model did not request coordinates.
+    assert tensor_to_embedding_blob(torch.randn(1280))[0] == _COMPACT_VERSION
+    assert tensor_to_embedding_blob(_sparse_vector(131072, 0.036))[0] == _COMPACT_VERSION
+
+
+def test_sparse_blob_roundtrips_exactly() -> None:
+    vector = _sparse_vector(65536, 0.087)  # (w,)
+
+    recovered = embedding_blob_to_tensor(tensor_to_embedding_blob(vector, sparse=True))  # (w,)
+
+    assert recovered.dtype == vector.dtype
+    assert recovered.shape == vector.shape
+    assert torch.equal(recovered, vector)
+
+
+def test_sparse_blob_shrinks_wide_codebooks() -> None:
+    vector = _sparse_vector(131072, 0.036)  # (w,)
+
+    blob = tensor_to_embedding_blob(vector, sparse=True)
+
+    dense_bytes = vector.numel() * vector.element_size()
+    assert len(blob) < 0.15 * dense_bytes
+
+
+def test_dense_format_is_never_larger_than_the_payload() -> None:
+    vector = _sparse_vector(8192, 0.5)  # (w,)
+
+    blob = tensor_to_embedding_blob(vector)
+
+    assert blob[0] == _COMPACT_VERSION
+    assert len(blob) <= vector.numel() * vector.element_size() + 16
+
+
+def test_bfloat16_sparse_blob_roundtrips() -> None:
+    vector = _sparse_vector(65536, 0.05, dtype=torch.bfloat16)  # (w,)
+
+    recovered = embedding_blob_to_tensor(tensor_to_embedding_blob(vector, sparse=True))  # (w,)
+
+    assert recovered.dtype == torch.bfloat16
+    assert torch.equal(recovered, vector)
+
+
+def test_batch_applies_one_format_to_every_row() -> None:
+    width = 131072  # w
+    batch = torch.zeros(3, width, dtype=torch.float16)  # (b, w)
+    for row, count in enumerate((100, 5_000, 120_000)):
+        batch[row, torch.randperm(width)[:count]] = 1.5
+
+    blobs = batch_tensor_to_blobs(batch, sparse=True)
+
+    assert [blob[0] for blob in blobs] == [_SPARSE_VERSION] * 3
+    for row, blob in enumerate(blobs):
+        assert torch.equal(embedding_blob_to_tensor(blob), batch[row])
+
+
+def test_batch_of_dense_embeddings_matches_single_serialization() -> None:
+    batch = torch.randn(4, 320, dtype=torch.float32)  # (b, d)
+
+    blobs = batch_tensor_to_blobs(batch)
+
+    assert blobs == [tensor_to_embedding_blob(batch[row]) for row in range(batch.shape[0])]
+
+
+def test_sparse_matrix_embedding_roundtrips() -> None:
+    torch.manual_seed(0)
+    matrix = torch.zeros(7, 65536, dtype=torch.float16)  # (l, w)
+    matrix[torch.randint(0, 7, (400,)), torch.randint(0, 65536, (400,))] = 2.0
+
+    recovered = embedding_blob_to_tensor(tensor_to_embedding_blob(matrix, sparse=True))  # (l, w)
+
+    assert recovered.shape == matrix.shape
+    assert torch.equal(recovered, matrix)
+
+
+def test_bfloat16_keeps_values_below_the_float16_normal_range() -> None:
+    # bfloat16 has a wider exponent than float16, so storing it as float16 bytes lost
+    # small magnitudes. These are the values that used to come back changed.
+    vector = torch.tensor([1.0e-6, 3.0e-8, 1.0e-30, 1.0, -2.5], dtype=torch.bfloat16)  # (d,)
+
+    recovered = embedding_blob_to_tensor(tensor_to_embedding_blob(vector))  # (d,)
+
+    assert recovered.dtype == torch.bfloat16
+    assert torch.equal(recovered, vector)
+
+
+def test_sparse_bfloat16_keeps_small_magnitudes() -> None:
+    vector = torch.zeros(8192, dtype=torch.bfloat16)  # (w,)
+    vector[5] = 1.0e-6
+    vector[9] = 1.0e-30
+
+    recovered = embedding_blob_to_tensor(tensor_to_embedding_blob(vector, sparse=True))  # (w,)
+
+    assert recovered.dtype == torch.bfloat16
+    assert torch.equal(recovered, vector)
+
+
+def test_legacy_bfloat16_blobs_still_read() -> None:
+    # Caches written before the fix tagged float16 bytes with dtype code 1.
+    values = torch.tensor([1.0, -2.5, 0.5], dtype=torch.bfloat16)  # (d,)
+    legacy = struct.pack('<BBii', _COMPACT_VERSION, 1, 1, 3) + values.half().numpy().tobytes()
+
+    recovered = embedding_blob_to_tensor(legacy)  # (d,)
+
+    assert recovered.dtype == torch.bfloat16
+    assert torch.equal(recovered, values)
+
+
+def test_negative_zero_survives_the_coordinate_list_format_as_zero() -> None:
+    # The sparse writer keeps only non-zero entries, and negative zero is not one, so it
+    # comes back as positive zero. The two compare equal, which is all callers rely on.
+    vector = torch.zeros(4096, dtype=torch.float16)  # (w,)
+    vector[7] = -0.0
+    vector[11] = 2.5
+
+    recovered = embedding_blob_to_tensor(tensor_to_embedding_blob(vector, sparse=True))  # (w,)
+
+    assert torch.equal(recovered, vector)
+
+
+def test_batch_and_single_serialization_agree_in_both_formats() -> None:
+    width = 8192  # w
+    batch = torch.zeros(4, width, dtype=torch.float16)  # (b, w)
+    for row, count in enumerate((10, 1_000, 3_000, 7_000)):
+        batch[row, torch.randperm(width)[:count]] = 1.25
+
+    for sparse in (False, True):
+        blobs = batch_tensor_to_blobs(batch, sparse=sparse)
+        assert blobs == [
+            tensor_to_embedding_blob(batch[row], sparse=sparse) for row in range(batch.shape[0])
+        ]
+
+
+def test_all_zero_embedding_roundtrips() -> None:
+    vector = torch.zeros(4096, dtype=torch.float16)  # (w,)
+
+    blob = tensor_to_embedding_blob(vector, sparse=True)
+
+    assert blob[0] == _SPARSE_VERSION
+    assert torch.equal(embedding_blob_to_tensor(blob), vector)

--- a/src/protify/utils.py
+++ b/src/protify/utils.py
@@ -14,18 +14,80 @@ torch_load = partial(torch.load, map_location='cpu', weights_only=True)
 # Compact blob serialization constants
 # Canonical source: core/embed/blob.py. Keep in sync with fastplms/embedding_mixin.py.
 _COMPACT_VERSION = 0x01
-_DTYPE_TO_CODE = {torch.float16: 0, torch.bfloat16: 1, torch.float32: 2}
-_CODE_TO_DTYPE = {0: torch.float16, 1: torch.bfloat16, 2: torch.float32}
-_CODE_TO_NP_DTYPE = {0: np.float16, 1: np.float16, 2: np.float32}
+# Code 1 is the original bfloat16 encoding, which converted to float16 bytes. bfloat16
+# carries a wider exponent than float16, so that conversion silently flushed values below
+# the float16 normal range: 1.0e-6 came back as 1.01e-6. Code 3 stores the bfloat16 bit
+# pattern instead and is exact. Code 1 is still read so existing caches keep working.
+_LEGACY_BFLOAT16_CODE = 1
+_DTYPE_TO_CODE = {torch.float16: 0, torch.float32: 2, torch.bfloat16: 3}
+_CODE_TO_DTYPE = {0: torch.float16, 1: torch.bfloat16, 2: torch.float32, 3: torch.bfloat16}
+_CODE_TO_NP_DTYPE = {0: np.float16, 1: np.float16, 2: np.float32, 3: np.int16}
+
+# Coordinate-list blob format, selected by the model that produces the embedding.
+# Sparse autoencoder features are the case that pays: per-residue features have exactly
+# k of codebook_dim active whatever the sequence length, and max-pooled features measured
+# 3.6% dense at codebook width 131072. Ordinary PLM embeddings have no exact zeros.
+_SPARSE_VERSION = 0x02
+_INDEX_CODE_TO_NP = {0: np.uint16, 1: np.uint32}
+_UINT16_INDEX_LIMIT = 1 << 16
 
 
-def tensor_to_embedding_blob(tensor: torch.Tensor) -> bytes:
+def _index_code(numel: int) -> int:
+    """Narrowest index width that addresses a flattened embedding of this size."""
+    return 0 if numel <= _UINT16_INDEX_LIMIT else 1
+
+
+def _raw_value_bytes(t: torch.Tensor) -> bytes:
+    # numpy has no bfloat16, so those tensors travel as their own 2-byte bit pattern.
+    if t.dtype == torch.bfloat16:
+        return t.contiguous().view(torch.int16).numpy().tobytes()
+
+    return t.numpy().tobytes()
+
+
+def _restore_dtype(t: torch.Tensor, dtype_code: int) -> torch.Tensor:
+    """Recover the stored dtype from the raw array a blob decodes to."""
+    if dtype_code == _LEGACY_BFLOAT16_CODE:
+        return t.to(torch.bfloat16)  # float16 values written before code 3 existed
+    if _CODE_TO_DTYPE[dtype_code] == torch.bfloat16:
+        return t.view(torch.bfloat16)  # raw bit pattern
+
+    return t
+
+
+def _sparse_blob(t: torch.Tensor, dtype_code: int, index_code: int) -> bytes:
+    """Serialize one tensor as flat indices plus values.
+
+    Format: [version:1][dtype_code:1][index_code:1][ndim:4][shape:4*ndim][nnz:4]
+            [indices:nnz*index_width][values:nnz*value_width]
+    """
+    # t: arbitrary rank; flat: (numel,)
+    flat = t.reshape(-1)
+    indices = torch.nonzero(flat, as_tuple=False).reshape(-1)  # (nnz,)
+    shape = tuple(t.shape)
+    header = struct.pack(
+        f'<BBBi{len(shape)}ii',
+        _SPARSE_VERSION,
+        dtype_code,
+        index_code,
+        len(shape),
+        *shape,
+        indices.numel(),
+    )
+    index_bytes = indices.numpy().astype(_INDEX_CODE_TO_NP[index_code]).tobytes()
+    return header + index_bytes + _raw_value_bytes(flat[indices])
+
+
+def tensor_to_embedding_blob(tensor: torch.Tensor, sparse: bool = False) -> bytes:
     """Serialize a tensor to compact binary format for SQLite blob storage.
 
     Format: [version:1][dtype_code:1][ndim:4][shape:4*ndim][raw_bytes]
-    bfloat16 tensors are stored as float16 bytes (numpy lacks bfloat16)
-    but tagged with dtype_code=1 so they can be cast back on read.
+    bfloat16 tensors keep their own bit pattern under dtype_code=3.
     Falls back to torch.save for unsupported dtypes.
+
+    `sparse` selects the coordinate-list format. The caller decides it, because whether
+    coordinates pay follows from the model producing the embedding rather than from any
+    single tensor: see `EsmcSaeForEmbedding.sparse_storage`.
     """
     t = tensor.cpu()
     if t.dtype not in _DTYPE_TO_CODE:
@@ -34,14 +96,12 @@ def tensor_to_embedding_blob(tensor: torch.Tensor) -> bytes:
         return buffer.getvalue()
     dtype_code = _DTYPE_TO_CODE[t.dtype]
 
-    if t.dtype == torch.bfloat16:
-        raw = t.half().numpy().tobytes()
-    else:
-        raw = t.numpy().tobytes()
+    if sparse:
+        return _sparse_blob(t, dtype_code, _index_code(t.numel()))
 
     shape = t.shape
     header = struct.pack(f'<BBi{len(shape)}i', _COMPACT_VERSION, dtype_code, len(shape), *shape)
-    return header + raw
+    return header + _raw_value_bytes(t)
 
 
 def _compact_header(dtype: torch.dtype, shape: tuple) -> bytes:
@@ -50,25 +110,73 @@ def _compact_header(dtype: torch.dtype, shape: tuple) -> bytes:
     return struct.pack(f'<BBi{len(shape)}i', _COMPACT_VERSION, dtype_code, len(shape), *shape)
 
 
-def batch_tensor_to_blobs(batch: torch.Tensor) -> list:
+def _dense_blobs(rows: torch.Tensor, shape: tuple) -> list:
+    """Serialize a block of rows in the compact dense format, in one numpy conversion."""
+    # rows: (n, *shape)
+    header = _compact_header(rows.dtype, shape)
+    raw = _raw_value_bytes(rows)
+    stride = len(raw) // max(rows.shape[0], 1)
+    return [header + raw[i * stride:(i + 1) * stride] for i in range(rows.shape[0])]
+
+
+def _sparse_blobs(rows: torch.Tensor, shape: tuple, dtype_code: int, index_code: int) -> list:
+    """Serialize a block of sparse rows in one pass.
+
+    One `nonzero` call and one numpy conversion cover the whole block, then each row
+    takes a slice of the shared index and value buffers. `torch.nonzero` orders
+    coordinates by row, so those slices are contiguous.
+    """
+    # rows: (n, numel)
+    coordinates = torch.nonzero(rows, as_tuple=False)  # (nnz_total, 2)
+    counts = torch.bincount(coordinates[:, 0], minlength=rows.shape[0])  # (n,)
+    values = rows[coordinates[:, 0], coordinates[:, 1]]  # (nnz_total,)
+
+    index_dtype = _INDEX_CODE_TO_NP[index_code]
+    index_buffer = coordinates[:, 1].numpy().astype(index_dtype).tobytes()
+    value_buffer = _raw_value_bytes(values)
+    index_width = index_dtype().itemsize
+    value_width = len(value_buffer) // max(len(values), 1)
+
+    blobs = []
+    start = 0
+    for nnz in counts.tolist():
+        header = struct.pack(
+            f'<BBBi{len(shape)}ii', _SPARSE_VERSION, dtype_code, index_code, len(shape), *shape, nnz
+        )
+        stop = start + nnz
+        blobs.append(
+            header
+            + index_buffer[start * index_width:stop * index_width]
+            + value_buffer[start * value_width:stop * value_width]
+        )
+        start = stop
+
+    return blobs
+
+
+def batch_tensor_to_blobs(batch: torch.Tensor, sparse: bool = False) -> list:
     """Serialize a batch of identically-shaped embeddings to compact blobs.
 
-    Input: (B, D) or (B, L, D) tensor already on CPU and in target dtype.
-    Returns: list of B bytes objects, one per embedding.
-    Much faster than calling tensor_to_embedding_blob() per row because
-    dtype cast, numpy conversion, and header construction happen once.
+    Input: (b, d) or (b, l, d) tensor already on CPU and in target dtype.
+    Returns: list of b bytes objects, one per embedding.
+
+    Both formats are written in one bulk numpy conversion for the whole batch, which is
+    much faster than serializing row by row. `sparse` selects the coordinate-list format;
+    the caller decides it from the model, so ordinary embeddings pay nothing for it.
     """
     assert batch.dtype in _DTYPE_TO_CODE, f"Unsupported dtype {batch.dtype}"
     single_shape = tuple(batch.shape[1:])
-    header = _compact_header(batch.dtype, single_shape)
 
-    if batch.dtype == torch.bfloat16:
-        raw = batch.half().numpy().tobytes()
-    else:
-        raw = batch.numpy().tobytes()
+    if not sparse:
+        return _dense_blobs(batch, single_shape)
 
-    stride = raw.__len__() // batch.shape[0]
-    return [header + raw[i * stride:(i + 1) * stride] for i in range(batch.shape[0])]
+    numel = int(np.prod(single_shape)) if single_shape else 1
+    return _sparse_blobs(
+        batch.reshape(batch.shape[0], -1),
+        single_shape,
+        _DTYPE_TO_CODE[batch.dtype],
+        _index_code(numel),
+    )
 
 
 def embedding_blob_to_tensor(
@@ -77,9 +185,28 @@ def embedding_blob_to_tensor(
 ) -> torch.Tensor:
     """Deserialize an embedding blob from SQLite.
 
-    Tries compact binary format first (version byte 0x01), then PyTorch
-    torch.save format, then legacy raw float32 with fallback_shape.
+    Tries compact binary format first (version byte 0x01), then the coordinate-list
+    format (0x02), then PyTorch torch.save format, then legacy raw float32 with
+    fallback_shape. Both compact formats return a dense tensor.
     """
+    if len(blob) >= 3 and blob[0] == _SPARSE_VERSION and blob[1] in _CODE_TO_DTYPE:
+        dtype_code = blob[1]
+        index_code = blob[2]
+        ndim = struct.unpack_from('<i', blob, 3)[0]
+        shape = struct.unpack_from(f'<{ndim}i', blob, 7)
+        nnz = struct.unpack_from('<i', blob, 7 + 4 * ndim)[0]
+        np_dtype = _CODE_TO_NP_DTYPE[dtype_code]
+        np_index_dtype = _INDEX_CODE_TO_NP[index_code]
+
+        index_offset = 11 + 4 * ndim
+        indices = np.frombuffer(blob, dtype=np_index_dtype, count=nnz, offset=index_offset)  # (nnz,)
+        value_offset = index_offset + nnz * np_index_dtype().itemsize
+        values = np.frombuffer(blob, dtype=np_dtype, count=nnz, offset=value_offset)  # (nnz,)
+
+        dense = np.zeros(int(np.prod(shape)) if shape else 1, dtype=np_dtype)  # (numel,)
+        dense[indices] = values
+        return _restore_dtype(torch.from_numpy(dense.reshape(shape)), dtype_code)
+
     if len(blob) >= 2 and blob[0] == _COMPACT_VERSION and blob[1] in _CODE_TO_DTYPE:
         dtype_code = blob[1]
         ndim = struct.unpack_from('<i', blob, 2)[0]
@@ -87,10 +214,7 @@ def embedding_blob_to_tensor(
         data_offset = 6 + 4 * ndim
         np_dtype = _CODE_TO_NP_DTYPE[dtype_code]
         arr = np.frombuffer(blob, dtype=np_dtype, offset=data_offset).reshape(shape).copy()
-        t = torch.from_numpy(arr)
-        if dtype_code == 1:
-            t = t.to(torch.bfloat16)
-        return t
+        return _restore_dtype(torch.from_numpy(arr), dtype_code)
 
     try:
         t = torch_load(io.BytesIO(blob))

--- a/src/protify/utils.py
+++ b/src/protify/utils.py
@@ -11,8 +11,13 @@ import numpy as np
 
 torch_load = partial(torch.load, map_location='cpu', weights_only=True)
 
-# Compact blob serialization constants
-# Canonical source: core/embed/blob.py. Keep in sync with fastplms/embedding_mixin.py.
+# Compact blob serialization constants. Canonical source: core/embed/blob.py.
+#
+# FastPLMs reads Protify caches through `_decode_legacy_sqlite_blob` in
+# fastplms/embeddings/storage.py, which currently accepts version 0x01 with dtype codes 0
+# to 2 only. Dtype code 3 and the coordinate-list version 0x02 below are both newer than
+# that reader, so a cache written here since they landed does not import there until
+# FastPLMs gains them. Adding them is a change to the vendored repository, not to Protify.
 _COMPACT_VERSION = 0x01
 # Code 1 is the original bfloat16 encoding, which converted to float16 bytes. bfloat16
 # carries a wider exponent than float16, so that conversion silently flushed values below

--- a/src/protify/yamls/base.yaml
+++ b/src/protify/yamls/base.yaml
@@ -34,8 +34,17 @@ data_dirs: []
 
 
 # BaseModelArguments:
+# ESMC-300-SAE resolves to ESMC-300-SAE-l23-k64-c8192: ESMC 300M read through the Biohub
+# sparse autoencoder at layer 23. Max pooling over its codebook gives sparse features that
+# suit the xgboost probe below. Swap in ESM2-8 for a small dense-embedding baseline.
 model_names:
-  - ESM2-8
+  - ESMC-300-SAE
+# Other ESMC sparse autoencoders: ESMC-600-SAE and ESMC-6B-SAE. A bare alias resolves to
+# the 75% depth layer each backbone publishes (23, 27, and 60). The three settings below
+# override that; leave them null for the defaults.
+sae_layer: null           # any layer 0..n_layers, but only at k 64 and codebook 16384
+sae_k: null               # 16, 32, 64, 128, 256, or 512; depth layer only for non-64
+sae_codebook_dim: null    # 8192, 16384, 32768, 65536, or 131072; depth layer only
 # Alternative: use model_paths + model_types instead of model_names (mutually exclusive)
 # model_paths:
 #   - answerdotai/ModernBERT-base
@@ -44,8 +53,9 @@ model_names:
 
 
 # ProbeArguments:
-probe_type: linear  # valid options: linear, transformer, lyra
+probe_type: xgboost  # valid options: mlp, transformer, lyra, xgboost, lightgbm, random_forest ("linear" is the former name for mlp)
 tokenwise: !!bool false
+probe_n_jobs: !!int -1  # workers for xgboost, lightgbm, and random_forest probes
 hidden_size: !!int 8192
 dropout: !!float 0.2
 n_layers: !!int 1
@@ -83,8 +93,10 @@ embedding_batch_size: !!int 4
 num_workers: !!int 0
 download_embeddings: !!bool false
 matrix_embed: !!bool false
+# SAE models accept max, mean, and sum only, and pool inside their encoder pass.
+# Dense embedding models accept the full set in pooler.py.
 embedding_pooling_types:
-  - mean
+  - max
 embedding_hidden_state_index: !!int -1
 save_embeddings: !!bool false
 embed_dtype: !!str float32


### PR DESCRIPTION
Makes ESMC sparse autoencoders a first-class Protify workflow, adds tree-based estimator probes, and moves the SAE runtime onto the upstream FastPLMs port.

## FastPLMs submodule

Bumped `src/protify/fastplms` from `5b54dbd` to **`1f78282`** ("porting SAE"), the current tip of `Synthyra/FastPLMs@main`. That commit ports the Biohub hidden-state SAE contract upstream, so the SAE runtime Protify was carrying locally is now redundant and has been removed.

Ownership is split along the repository boundary:

- **FastPLMs** runs the SAE. `ESMplusplusModel.load_sae_models` attaches a Biohub checkpoint, and a forward pass with `compute_sae=True` returns one sparse `(valid_tokens, codebook_dim)` tensor per attached layer.
- **Protify** (`base_models/esmc_sae.py`) owns the published-coverage registry, model-name resolution, pooling to one vector per protein, and the storage policy.

`AGENTS.md` records that boundary so the encoder does not get reimplemented here.

### Behavior change: existing SAE caches are stale

The upstream layer standardizes each residue as `(x - mean) / (std + 1e-5)`. The earlier local implementation scaled to unit RMS without centering. This changes every SAE embedding value.

Cache filenames key on the resolved model name, which did not change, so **a pre-existing `*-SAE-*` cache will be silently reused and must be deleted.** Max-pooled density on `solubility` at k=64/c8192 moved from 23.7% to 36.6%. The storage policy still selects correctly at both ends (8.9% sparse at k=16, 36.6% dense at k=64, break-even ~45%).

## SAE workflows

Use `ESMC-300-SAE`, `ESMC-600-SAE`, or `ESMC-6B-SAE`. A bare alias resolves to the layer at 75% depth at k=64 and codebook 8192; `--sae_layer`, `--sae_k`, and `--sae_codebook_dim` override it. The resolved name (`ESMC-300-SAE-l23-k64-c8192`) carries the full checkpoint identity, so it reaches the embedding cache filename and the results table without a separate cache key, and two variants never share a cache. Requesting a combination Biohub does not publish raises and names the valid options.

SAE models accept `max`, `mean`, and `sum`, and reject `--matrix_embed`: one residue at codebook 131072 costs 256 KiB dense. Pooling drops the leading and trailing special tokens, matching the Biohub reference workflow.

## Estimator probes

`xgboost`, `lightgbm`, and `random_forest` run through `run_estimator_probes`, sharing the embedding cache and results table with the neural probes. They skip embedding standardization, which cannot change a tree's splits and would densify sparse features. `--scikit_model_args` overrides any default.

## Storage

Coordinate-list blobs (format `0x02`) are selected per model, from `EsmcSaeForEmbedding.sparse_storage`, when the active fraction `k / codebook_dim` is low enough to pay for it. Every other model writes dense and pays nothing for the feature. At codebook 65536, 200 proteins stored 3.2 MB against 26.2 MB dense.

bfloat16 now keeps its own bit pattern under dtype code 3. Code 1 is the older float16-byte encoding, which lost values below the float16 normal range (`1.0e-6` became `1.01e-6`); it is still read and never written.

## Probe rename

`linear_probe.py` becomes `mlp_probe.py` and `mlp` is the current `probe_type`, since the probe is not a linear model. `linear` still resolves, because saved probe configs, exported repositories, and existing YAML carry it, and `MLPProbeConfig.model_type` stays `linear_probe`.

## Pair-order fix

The numpy dataset builder called `_random_order` on every row of train, validation, **and** test, ungated by `--random_pair_flipping`. Swapping evaluation pairs makes a reported score depend on the random state. Swapping is now train-only and gated on the flag, matching the neural path. Four regression tests pin the evaluation splits to dataset order.

## Verification

Pooling was checked on GPU against a manual dense reduction of the raw FastPLMs output: `max`, `mean`, and `sum` all match, special tokens are excluded, and embeddings are padding-invariant (batch composition does not change a protein's vector).

Two workflows ran end to end on `solubility`:

| Config | Storage | Result |
|---|---|---|
| k=16/c8192, XGBoost, `--sql` | coordinate-list, dtype code 3 | MCC 0.495, ROC-AUC 0.838 |
| k=64/c8192, MLP probe, `--sql` | dense | MCC 0.456, ROC-AUC 0.813 |

Protify suite: **474 passed, 1 failed** — the pre-existing `test_fastplms_validation_dependency_versions`, which pins `transformers==5.13.0` against the image's 5.13.1.

FastPLMs suite at `1f78282`: 836 passed, 8 failed. Five are pre-existing or CUDA-only. The other three are the new SAE parity tests, which need `vendor/upstream/biohub-transformers` as an oracle; that directory is empty in this checkout, so they want a vendor sync rather than a code fix.

## Not included

- The XGBoost defaults were selected before this port and were not reselected against the new feature distribution. Noted in `ESTIMATOR_DEFAULTS` and the docs.
- `normalize_sae=True` is available upstream but not exposed as a Protify flag; it would have to reach the cache filename to keep the variants separable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
